### PR TITLE
Adjust the top navigation bar to center both the Home button and some divs on the right.

### DIFF
--- a/client/src/components/app_bar.tsx
+++ b/client/src/components/app_bar.tsx
@@ -165,7 +165,7 @@ export function WelcomeAppBar({pageNumber, setPageNumber, gameInfo, toggleImpres
   const [navOpen, setNavOpen] = React.useState(false)
 
   return <div className="app-bar">
-    <div>
+    <div className='app-bar-left'>
       <Button inverted="false" title="back to games selection" to="/">
         <FontAwesomeIcon icon={faArrowLeft} />&nbsp;<FontAwesomeIcon icon={faGlobe} />
       </Button>
@@ -237,7 +237,7 @@ export function LevelAppBar({isLoading, levelTitle, toggleImpressum, pageNumber=
       </> :
       <>
         {/* DESKTOP VERSION */}
-        <div>
+        <div className='app-bar-left'>
           <HomeButton isDropdown={false} />
           <span className="app-bar-title">{worldTitle && `World: ${worldTitle}`}</span>
         </div>

--- a/client/src/css/app.css
+++ b/client/src/css/app.css
@@ -105,9 +105,15 @@ em {
   position: relative;
   flex-direction: row;
   justify-content: space-between;
+  align-items: center;
   padding: 1.1em;
   filter: drop-shadow(0 0 5px rgba(0,0,0,0.5));
   z-index: 2;
+}
+
+.app-bar > .app-bar-left{
+  display: flex;
+  align-items: center;
 }
 
 .app-bar-title, .app-bar-subtitle {


### PR DESCRIPTION
## Description
Adjust the top navigation bar to center both the Home button and some divs on the right.


While working on the move button and other related issues, I noticed that the fonts and icons in the top navigation bar are not centered, which I find puzzling.

So, do you think this look is correct?


before:
![image](https://github.com/leanprover-community/lean4game/assets/90966139/2c910bf7-a911-4446-b641-111203cbf83a)


after:
![image](https://github.com/leanprover-community/lean4game/assets/90966139/0233f019-1121-452e-965d-7fddd21f0779)

Okay, these two pictures don’t seem to be very clear, but if you look carefully at the ```home button```, you should be able to see it.

