### PR TITLE
Modify logic for preferences

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -8,49 +8,24 @@ import '@fontsource/roboto/700.css';
 
 import './css/reset.css';
 import './css/app.css';
-import { MobileContext, PreferencesContext} from './components/infoview/context';
-import { AUTO_SWITCH_THRESHOLD, getWindowDimensions, setLayout, setisSavePreferences, PreferencesState} from './state/preferences';
-import { useAppDispatch, useAppSelector } from './hooks';
+import { PreferencesContext} from './components/infoview/context';
+import UsePreferences from "./state/hooks/use_preferences"
 
 export const GameIdContext = React.createContext<string>(undefined);
 
 function App() {
-  const dispatch = useAppDispatch()
 
   const params = useParams()
   const gameId = "g/" + params.owner + "/" + params.repo
 
-  // TODO: Modifying setMobile will not change 'layout', and the setMobile function may not exist in the future.
-  const [mobile, setMobile] = React.useState<boolean>()
-  const layout = useAppSelector((state) => state.preferences.layout);
-  const changeLayout = (layout: PreferencesState["layout"]) => dispatch(setLayout(layout))
-  const isSavePreferences = useAppSelector((state) => state.preferences.isSavePreferences);
-  const changeIsSavePreferences = (isSave: boolean) => dispatch(setisSavePreferences(isSave))
-
-  const automaticallyAdjustLayout = () => {
-    const {width} = getWindowDimensions()
-    setMobile(width < AUTO_SWITCH_THRESHOLD)
-  }
-
-  React.useEffect(()=>{
-    if (layout === "auto"){
-      void automaticallyAdjustLayout()
-      window.addEventListener('resize', automaticallyAdjustLayout)
-
-      return () => window.removeEventListener('resize', automaticallyAdjustLayout)
-    } else {
-      setMobile(layout === "mobile")
-    }
-  }, [layout])
+  const {mobile, layout, isSavePreferences, setLayout, setIsSavePreferences} = UsePreferences()
 
   return (
     <div className="app">
       <GameIdContext.Provider value={gameId}>
-        <MobileContext.Provider value={{mobile, setMobile}}>
-          <PreferencesContext.Provider value={{layout, isSavePreferences, setLayout: changeLayout, setIsSavePreferences: changeIsSavePreferences}}>
+          <PreferencesContext.Provider value={{mobile, layout, isSavePreferences, setLayout, setIsSavePreferences}}>
             <Outlet />
           </PreferencesContext.Provider>
-        </MobileContext.Provider>
       </GameIdContext.Provider>
     </div>
   )

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -20,7 +20,7 @@ function App() {
   const params = useParams()
   const gameId = "g/" + params.owner + "/" + params.repo
 
-  // TODO: 
+  // TODO: Modifying setMobile will not change 'layout', and the setMobile function may not exist in the future.
   const [mobile, setMobile] = React.useState<boolean>()
   const layout = useAppSelector((state) => state.preferences.layout);
   const changeLayout = (layout: PreferencesState["layout"]) => dispatch(setLayout(layout))

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -8,17 +8,24 @@ import '@fontsource/roboto/700.css';
 
 import './css/reset.css';
 import './css/app.css';
-import { MobileContext } from './components/infoview/context';
-import { useMobile } from './hooks';
-import { AUTO_SWITCH_THRESHOLD, getWindowDimensions} from './state/preferences';
+import { MobileContext, PreferencesContext} from './components/infoview/context';
+import { AUTO_SWITCH_THRESHOLD, getWindowDimensions, setLayout, setisSavePreferences, PreferencesState} from './state/preferences';
+import { useAppDispatch, useAppSelector } from './hooks';
 
 export const GameIdContext = React.createContext<string>(undefined);
 
 function App() {
-  const { mobile, setMobile, lockMobile, setLockMobile } = useMobile();
+  const dispatch = useAppDispatch()
 
   const params = useParams()
   const gameId = "g/" + params.owner + "/" + params.repo
+
+  // TODO: 
+  const [mobile, setMobile] = React.useState<boolean>()
+  const layout = useAppSelector((state) => state.preferences.layout);
+  const changeLayout = (layout: PreferencesState["layout"]) => dispatch(setLayout(layout))
+  const isSavePreferences = useAppSelector((state) => state.preferences.isSavePreferences);
+  const changeIsSavePreferences = (isSave: boolean) => dispatch(setisSavePreferences(isSave))
 
   const automaticallyAdjustLayout = () => {
     const {width} = getWindowDimensions()
@@ -26,21 +33,23 @@ function App() {
   }
 
   React.useEffect(()=>{
-    if (!lockMobile){
+    if (layout === "auto"){
       void automaticallyAdjustLayout()
       window.addEventListener('resize', automaticallyAdjustLayout)
 
-      return () => {
-        window.removeEventListener('resize', automaticallyAdjustLayout)
-      }
+      return () => window.removeEventListener('resize', automaticallyAdjustLayout)
+    } else {
+      setMobile(layout === "mobile")
     }
-  }, [lockMobile])
+  }, [layout])
 
   return (
     <div className="app">
       <GameIdContext.Provider value={gameId}>
-        <MobileContext.Provider value={{mobile, setMobile, lockMobile, setLockMobile}}>
-          <Outlet />
+        <MobileContext.Provider value={{mobile, setMobile}}>
+          <PreferencesContext.Provider value={{layout, isSavePreferences, setLayout: changeLayout, setIsSavePreferences: changeIsSavePreferences}}>
+            <Outlet />
+          </PreferencesContext.Provider>
         </MobileContext.Provider>
       </GameIdContext.Provider>
     </div>

--- a/client/src/components/app_bar.tsx
+++ b/client/src/components/app_bar.tsx
@@ -7,7 +7,7 @@ import { faDownload, faUpload, faEraser, faBook, faBookOpen, faGlobe, faHome,
   faArrowRight, faArrowLeft, faXmark, faBars, faCode,
   faCircleInfo, faTerminal, faMobileScreenButton, faDesktop, faGear } from '@fortawesome/free-solid-svg-icons'
 import { GameIdContext } from "../app"
-import { InputModeContext, MobileContext, WorldLevelIdContext } from "./infoview/context"
+import { InputModeContext, PreferencesContext, WorldLevelIdContext } from "./infoview/context"
 import { GameInfo, useGetGameInfoQuery } from '../state/api'
 import { changedOpenedIntro, selectCompleted, selectDifficulty, selectProgress } from '../state/progress'
 import { useAppDispatch, useAppSelector } from '../hooks'
@@ -162,7 +162,7 @@ export function WelcomeAppBar({pageNumber, setPageNumber, gameInfo, toggleImpres
 }) {
   const gameId = React.useContext(GameIdContext)
   const gameProgress = useAppSelector(selectProgress(gameId))
-  const {mobile, setMobile} = React.useContext(MobileContext)
+  const {mobile} = React.useContext(PreferencesContext)
   const [navOpen, setNavOpen] = React.useState(false)
 
   return <div className="app-bar">
@@ -212,7 +212,7 @@ export function LevelAppBar({isLoading, levelTitle, toggleImpressum, pageNumber=
 }) {
   const gameId = React.useContext(GameIdContext)
   const {worldId, levelId} = React.useContext(WorldLevelIdContext)
-  const {mobile} = React.useContext(MobileContext)
+  const {mobile} = React.useContext(PreferencesContext)
   const [navOpen, setNavOpen] = React.useState(false)
   const gameInfo = useGetGameInfoQuery({game: gameId})
   const completed = useAppSelector(selectCompleted(gameId, worldId, levelId))

--- a/client/src/components/infoview/context.ts
+++ b/client/src/components/infoview/context.ts
@@ -64,25 +64,17 @@ export const ProofStateContext = React.createContext<{
 })
 
 export interface IPreferencesContext extends PreferencesState{
+  mobile: boolean, // The variables that actually control the page 'layout' can only be changed through layout.
   setLayout: React.Dispatch<React.SetStateAction<PreferencesState["layout"]>>;
   setIsSavePreferences: React.Dispatch<React.SetStateAction<Boolean>>;
 }
 
 export const PreferencesContext = React.createContext<IPreferencesContext>({
+  mobile: false,
   layout: "auto",
   isSavePreferences: false,
   setLayout: () => {},
   setIsSavePreferences: () => {}
-})
-
-export interface IMobileContext {
-  mobile : boolean,
-  setMobile: React.Dispatch<React.SetStateAction<Boolean>>,
-}
-
-export const MobileContext = React.createContext<IMobileContext>({
-  mobile: false,
-  setMobile: () => {},
 })
 
 export const WorldLevelIdContext = React.createContext<{

--- a/client/src/components/infoview/context.ts
+++ b/client/src/components/infoview/context.ts
@@ -5,6 +5,7 @@ import * as React from 'react';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js'
 import { InteractiveDiagnostic, InteractiveTermGoal } from '@leanprover/infoview-api';
 import { GameHint, InteractiveGoal, InteractiveGoals } from './rpc_api';
+import { PreferencesState } from '../../state/preferences';
 
 export const MonacoEditorContext = React.createContext<monaco.editor.IStandaloneCodeEditor>(
   null as any)
@@ -62,18 +63,26 @@ export const ProofStateContext = React.createContext<{
   setProofState: () => {},
 })
 
+export interface IPreferencesContext extends PreferencesState{
+  setLayout: React.Dispatch<React.SetStateAction<PreferencesState["layout"]>>;
+  setIsSavePreferences: React.Dispatch<React.SetStateAction<Boolean>>;
+}
+
+export const PreferencesContext = React.createContext<IPreferencesContext>({
+  layout: "auto",
+  isSavePreferences: false,
+  setLayout: () => {},
+  setIsSavePreferences: () => {}
+})
+
 export interface IMobileContext {
   mobile : boolean,
   setMobile: React.Dispatch<React.SetStateAction<Boolean>>,
-  lockMobile: boolean,
-  setLockMobile: React.Dispatch<React.SetStateAction<Boolean>>,
 }
 
 export const MobileContext = React.createContext<IMobileContext>({
   mobile: false,
   setMobile: () => {},
-  lockMobile: false,
-  setLockMobile: () => {}
 })
 
 export const WorldLevelIdContext = React.createContext<{

--- a/client/src/components/infoview/main.tsx
+++ b/client/src/components/infoview/main.tsx
@@ -27,7 +27,7 @@ import Markdown from '../markdown';
 import { Infos } from './infos';
 import { AllMessages, Errors, WithLspDiagnosticsContext } from './messages';
 import { Goal } from './goals';
-import { DeletedChatContext, InputModeContext, MobileContext, MonacoEditorContext, ProofContext, ProofStep, SelectionContext, WorldLevelIdContext } from './context';
+import { DeletedChatContext, InputModeContext, PreferencesContext, MonacoEditorContext, ProofContext, ProofStep, SelectionContext, WorldLevelIdContext } from './context';
 import { Typewriter, hasErrors, hasInteractiveErrors } from './typewriter';
 import { InteractiveDiagnostic } from '@leanprover/infoview/*';
 import { Button } from '../button';
@@ -349,7 +349,7 @@ export function TypewriterInterface({props}) {
   const [disableInput, setDisableInput] = React.useState<boolean>(false)
   const [loadingProgress, setLoadingProgress] = React.useState<number>(0)
   const { setDeletedChat, showHelp, setShowHelp } = React.useContext(DeletedChatContext)
-  const {mobile} = React.useContext(MobileContext)
+  const {mobile} = React.useContext(PreferencesContext)
   const { proof } = React.useContext(ProofContext)
   const { setTypewriterInput } = React.useContext(InputModeContext)
   const { selectedStep, setSelectedStep } = React.useContext(SelectionContext)

--- a/client/src/components/level.tsx
+++ b/client/src/components/level.tsx
@@ -27,7 +27,7 @@ import { Button } from './button'
 import Markdown from './markdown'
 import {InventoryPanel} from './inventory'
 import { hasInteractiveErrors } from './infoview/typewriter'
-import { DeletedChatContext, InputModeContext, MobileContext, MonacoEditorContext,
+import { DeletedChatContext, InputModeContext, PreferencesContext, MonacoEditorContext,
   ProofContext, ProofStep, SelectionContext, WorldLevelIdContext } from './infoview/context'
 import { DualEditor } from './infoview/main'
 import { GameHint } from './infoview/rpc_api'
@@ -74,7 +74,7 @@ function Level() {
 
 function ChatPanel({lastLevel}) {
   const chatRef = useRef<HTMLDivElement>(null)
-  const {mobile} = useContext(MobileContext)
+  const {mobile} = useContext(PreferencesContext)
   const gameId = useContext(GameIdContext)
   const {worldId, levelId} = useContext(WorldLevelIdContext)
   const level = useLoadLevelQuery({game: gameId, world: worldId, level: levelId})
@@ -215,7 +215,7 @@ function PlayableLevel({impressum, setImpressum}) {
   const codeviewRef = useRef<HTMLDivElement>(null)
   const gameId = React.useContext(GameIdContext)
   const {worldId, levelId} = useContext(WorldLevelIdContext)
-  const {mobile} = React.useContext(MobileContext)
+  const {mobile} = React.useContext(PreferencesContext)
 
   const dispatch = useAppDispatch()
 
@@ -441,7 +441,7 @@ function PlayableLevel({impressum, setImpressum}) {
 function IntroductionPanel({gameInfo}) {
   const gameId = React.useContext(GameIdContext)
   const {worldId} = useContext(WorldLevelIdContext)
-  const {mobile} = React.useContext(MobileContext)
+  const {mobile} = React.useContext(PreferencesContext)
 
   let text: Array<string> = gameInfo.data?.worlds.nodes[worldId].introduction.split(/\n(\s*\n)+/)
 
@@ -468,7 +468,7 @@ export default Level
 /** The site with the introduction text of a world */
 function Introduction({impressum, setImpressum}) {
   const gameId = React.useContext(GameIdContext)
-  const {mobile} = useContext(MobileContext)
+  const {mobile} = useContext(PreferencesContext)
 
   const inventory = useLoadInventoryOverviewQuery({game: gameId})
 

--- a/client/src/components/popup/preferences.tsx
+++ b/client/src/components/popup/preferences.tsx
@@ -9,7 +9,7 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 
 import { IPreferencesContext } from "../infoview/context"
 
-interface PreferencesPopupProps extends IPreferencesContext {
+interface PreferencesPopupProps extends Omit<IPreferencesContext, 'mobile'> {
     handleClose: () => void
 }
 

--- a/client/src/components/popup/preferences.tsx
+++ b/client/src/components/popup/preferences.tsx
@@ -5,13 +5,10 @@ import { Switch, Button, ButtonGroup } from '@mui/material';
 
 import FormControlLabel from '@mui/material/FormControlLabel';
 
-import { IMobileContext } from "../infoview/context"
-import { PreferencesState } from "../../state/preferences"
+import { IPreferencesContext } from "../infoview/context"
 
-interface PreferencesPopupProps extends PreferencesState{
-    handleClose: () => void,
-    setLayout: (layout: "mobile" | "auto" | "desktop") => void,
-    setIsSavePreferences: (isSave: boolean) => void
+interface PreferencesPopupProps extends IPreferencesContext{
+    handleClose: () => void
 }
 
 export function PreferencesPopup({ layout, setLayout, isSavePreferences, setIsSavePreferences, handleClose }: PreferencesPopupProps) {    

--- a/client/src/components/popup/preferences.tsx
+++ b/client/src/components/popup/preferences.tsx
@@ -2,16 +2,41 @@ import * as React from 'react'
 import { Input, Typography } from '@mui/material'
 import Markdown from '../markdown'
 import { Switch, Button, ButtonGroup } from '@mui/material';
+import Box from '@mui/material/Box';
+import Slider from '@mui/material/Slider';
 
 import FormControlLabel from '@mui/material/FormControlLabel';
 
 import { IPreferencesContext } from "../infoview/context"
 
-interface PreferencesPopupProps extends IPreferencesContext{
+interface PreferencesPopupProps extends IPreferencesContext {
     handleClose: () => void
 }
 
-export function PreferencesPopup({ layout, setLayout, isSavePreferences, setIsSavePreferences, handleClose }: PreferencesPopupProps) {    
+export function PreferencesPopup({ layout, setLayout, isSavePreferences, setIsSavePreferences, handleClose }: PreferencesPopupProps) {
+
+    const marks = [
+        {
+            value: 0,
+            label: 'Mobile',
+            key: "mobile"
+        },
+        {
+            value: 1,
+            label: 'Auto',
+            key: "auto"
+        },
+        {
+            value: 2,
+            label: 'Desktop',
+            key: "desktop"
+        },
+    ];
+
+    const handlerChangeLayout = (_: Event, value: number) => {
+        setLayout(marks[value].key as IPreferencesContext["layout"])
+    }
+
     return <div className="modal-wrapper">
         <div className="modal-backdrop" onClick={handleClose} />
         <div className="modal">
@@ -24,11 +49,19 @@ export function PreferencesPopup({ layout, setLayout, isSavePreferences, setIsSa
                     <div className='preferences-item first leave-left-gap'>
                         <FormControlLabel
                             control={
-                                <ButtonGroup aria-label="outlined primary button group">
-                                    <Button onClick={() => setLayout("mobile")} variant={layout === "mobile" ? "contained" : "outlined"}>Mobile</Button>
-                                    <Button onClick={() => setLayout("auto")} variant={layout === "auto" ? "contained" : "outlined"}>Auto</Button>
-                                    <Button onClick={() => setLayout("desktop")} variant={layout === "desktop" ? "contained" : "outlined"}>Desktop</Button>
-                                </ButtonGroup>
+                                <Box sx={{ width: 300 }}>
+                                    <Slider
+                                        aria-label="Always visible"
+                                        value={marks.find(item => item.key === layout).value}
+                                        step={1}
+                                        marks={marks}
+                                        max={2}
+                                        sx={{
+                                            '& .MuiSlider-track': { display: 'none', },
+                                        }}
+                                        onChange={handlerChangeLayout}
+                                    />
+                                </Box>
                             }
                             label=""
                         />

--- a/client/src/components/popup/preferences.tsx
+++ b/client/src/components/popup/preferences.tsx
@@ -1,16 +1,20 @@
 import * as React from 'react'
 import { Input, Typography } from '@mui/material'
 import Markdown from '../markdown'
-import Switch from '@mui/material/Switch';
+import { Switch, Button, ButtonGroup } from '@mui/material';
+
 import FormControlLabel from '@mui/material/FormControlLabel';
 
 import { IMobileContext } from "../infoview/context"
+import { PreferencesState } from "../../state/preferences"
 
-interface PreferencesPopupProps extends IMobileContext{
-    handleClose: () => void
-} 
+interface PreferencesPopupProps extends PreferencesState{
+    handleClose: () => void,
+    setLayout: (layout: "mobile" | "auto" | "desktop") => void,
+    setIsSavePreferences: (isSave: boolean) => void
+}
 
-export function PreferencesPopup({ mobile, setMobile, lockMobile, setLockMobile, handleClose }: PreferencesPopupProps) {
+export function PreferencesPopup({ layout, setLayout, isSavePreferences, setIsSavePreferences, handleClose }: PreferencesPopupProps) {    
     return <div className="modal-wrapper">
         <div className="modal-backdrop" onClick={handleClose} />
         <div className="modal">
@@ -18,34 +22,35 @@ export function PreferencesPopup({ mobile, setMobile, lockMobile, setLockMobile,
             <Typography variant="body1" component="div" className="settings">
                 <div className='preferences-category'>
                     <div className='category-title'>
-                        <h3>Mobile layout</h3>
+                        <h3>Layout</h3>
                     </div>
-                    <div className='preferences-item'>
+                    <div className='preferences-item first leave-left-gap'>
                         <FormControlLabel
                             control={
-                            <Switch
-                                checked={mobile}
-                                onChange={() => setMobile(!mobile)}
-                                name="checked"
-                                color="primary"
-                            />
+                                <ButtonGroup aria-label="outlined primary button group">
+                                    <Button onClick={() => setLayout("mobile")} variant={layout === "mobile" ? "contained" : "outlined"}>Mobile</Button>
+                                    <Button onClick={() => setLayout("auto")} variant={layout === "auto" ? "contained" : "outlined"}>Auto</Button>
+                                    <Button onClick={() => setLayout("desktop")} variant={layout === "desktop" ? "contained" : "outlined"}>Desktop</Button>
+                                </ButtonGroup>
                             }
-                            label="Enable"
-                            labelPlacement="start"
+                            label=""
                         />
                     </div>
+                </div>
+
+                <div className='preferences-category tail-category'>
                     <div className='preferences-item'>
                         <FormControlLabel
                             control={
-                            <Switch
-                                checked={!lockMobile}
-                                onChange={() => setLockMobile(!lockMobile)}
-                                name="checked"
-                                color="primary"
-                            />
+                                <Switch
+                                    checked={isSavePreferences}
+                                    onChange={() => setIsSavePreferences(!isSavePreferences)}
+                                    name="checked"
+                                    color="primary"
+                                />
                             }
-                            label="Auto"
-                            labelPlacement="start"
+                            label="Save my settings (in the browser store)"
+                            labelPlacement="end"
                         />
                     </div>
                 </div>

--- a/client/src/components/welcome.tsx
+++ b/client/src/components/welcome.tsx
@@ -10,7 +10,7 @@ import { useAppDispatch, useAppSelector } from '../hooks'
 import { changedOpenedIntro, selectOpenedIntro } from '../state/progress'
 import { useGetGameInfoQuery, useLoadInventoryOverviewQuery } from '../state/api'
 import { Button } from './button'
-import { MobileContext } from './infoview/context'
+import { MobileContext, PreferencesContext } from './infoview/context'
 import { InventoryPanel } from './inventory'
 import { ErasePopup } from './popup/erase'
 import { InfoPopup } from './popup/game_info'
@@ -64,7 +64,9 @@ function IntroductionPanel({introduction, setPageNumber}: {introduction: string,
 /** main page of the game showing among others the tree of worlds/levels */
 function Welcome() {
   const gameId = React.useContext(GameIdContext)
-  const {mobile, setMobile, lockMobile, setLockMobile} = React.useContext(MobileContext)
+  const {mobile, setMobile} = React.useContext(MobileContext)
+  const {layout, isSavePreferences, setLayout, setIsSavePreferences} = React.useContext(PreferencesContext)
+
   const gameInfo = useGetGameInfoQuery({game: gameId})
   const inventory = useLoadInventoryOverviewQuery({game: gameId})
 
@@ -134,7 +136,7 @@ function Welcome() {
     {eraseMenu? <ErasePopup handleClose={closeEraseMenu}/> : null}
     {uploadMenu? <UploadPopup handleClose={closeUploadMenu}/> : null}
     {info ? <InfoPopup info={gameInfo.data?.info} handleClose={closeInfo}/> : null}
-    {preferencesPopup ? <PreferencesPopup mobile={mobile} setMobile={setMobile} lockMobile={lockMobile} setLockMobile={setLockMobile} handleClose={closePreferencesPopup}/> : null}
+    {preferencesPopup ? <PreferencesPopup layout={layout} isSavePreferences={isSavePreferences} setLayout={setLayout} setIsSavePreferences={setIsSavePreferences} handleClose={closePreferencesPopup}/> : null}
   </>
 }
 

--- a/client/src/components/welcome.tsx
+++ b/client/src/components/welcome.tsx
@@ -10,7 +10,7 @@ import { useAppDispatch, useAppSelector } from '../hooks'
 import { changedOpenedIntro, selectOpenedIntro } from '../state/progress'
 import { useGetGameInfoQuery, useLoadInventoryOverviewQuery } from '../state/api'
 import { Button } from './button'
-import { MobileContext, PreferencesContext } from './infoview/context'
+import { PreferencesContext } from './infoview/context'
 import { InventoryPanel } from './inventory'
 import { ErasePopup } from './popup/erase'
 import { InfoPopup } from './popup/game_info'
@@ -27,7 +27,7 @@ import { Hint } from './hints'
 
 /** the panel showing the game's introduction text */
 function IntroductionPanel({introduction, setPageNumber}: {introduction: string, setPageNumber}) {
-  const {mobile} = React.useContext(MobileContext)
+  const {mobile} = React.useContext(PreferencesContext)
   const gameId = React.useContext(GameIdContext)
   const dispatch = useAppDispatch()
 
@@ -64,7 +64,7 @@ function IntroductionPanel({introduction, setPageNumber}: {introduction: string,
 /** main page of the game showing among others the tree of worlds/levels */
 function Welcome() {
   const gameId = React.useContext(GameIdContext)
-  const {mobile, setMobile} = React.useContext(MobileContext)
+  const {mobile} = React.useContext(PreferencesContext)
   const {layout, isSavePreferences, setLayout, setIsSavePreferences} = React.useContext(PreferencesContext)
 
   const gameInfo = useGetGameInfoQuery({game: gameId})

--- a/client/src/components/world_tree.tsx
+++ b/client/src/components/world_tree.tsx
@@ -16,7 +16,7 @@ import { selectDifficulty, changedDifficulty, selectCompleted } from '../state/p
 import { store } from '../state/store'
 
 import '../css/world_tree.css'
-import { MobileContext } from './infoview/context'
+import { PreferencesContext } from './infoview/context'
 
 // Settings for the world tree
 cytoscape.use( klay )
@@ -198,7 +198,7 @@ export function WorldSelectionMenu({rulesHelp, setRulesHelp}) {
   const gameId = React.useContext(GameIdContext)
   const difficulty = useSelector(selectDifficulty(gameId))
   const dispatch = useAppDispatch()
-  const { mobile } = React.useContext(MobileContext)
+  const { mobile } = React.useContext(PreferencesContext)
 
 
   function label(x : number) {

--- a/client/src/components/world_tree.tsx
+++ b/client/src/components/world_tree.tsx
@@ -11,11 +11,12 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faXmark, faCircleQuestion } from '@fortawesome/free-solid-svg-icons'
 
 import { GameIdContext } from '../app'
-import { useAppDispatch, useMobile } from '../hooks'
+import { useAppDispatch } from '../hooks'
 import { selectDifficulty, changedDifficulty, selectCompleted } from '../state/progress'
 import { store } from '../state/store'
 
 import '../css/world_tree.css'
+import { MobileContext } from './infoview/context'
 
 // Settings for the world tree
 cytoscape.use( klay )
@@ -197,7 +198,7 @@ export function WorldSelectionMenu({rulesHelp, setRulesHelp}) {
   const gameId = React.useContext(GameIdContext)
   const difficulty = useSelector(selectDifficulty(gameId))
   const dispatch = useAppDispatch()
-  const { mobile } = useMobile()
+  const { mobile } = React.useContext(MobileContext)
 
 
   function label(x : number) {

--- a/client/src/css/welcome.css
+++ b/client/src/css/welcome.css
@@ -197,5 +197,5 @@ h5, h6 {
 }
 
 .preferences-item.leave-left-gap{
-  margin-left: 1em;
+  margin-left: 3em;
 }

--- a/client/src/css/welcome.css
+++ b/client/src/css/welcome.css
@@ -187,3 +187,15 @@ h5, h6 {
   margin-left: 0.3rem;
   margin-right: 0.3rem;
 }
+
+.preferences-category.tail-category{
+  margin-top: 2em;
+}
+
+.preferences-item.first{
+  margin-top: 1em;
+}
+
+.preferences-item.leave-left-gap{
+  margin-left: 1em;
+}

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -1,30 +1,6 @@
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
 import type { RootState, AppDispatch } from './state/store'
 
-import { setMobile as setMobileState, setLockMobile as setLockMobileState} from "./state/preferences"
-
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch: () => AppDispatch = useDispatch
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
-
-export const useMobile = () => {
-  const dispatch = useAppDispatch();
-
-  const mobile = useAppSelector((state) => state.preferences.mobile);
-  const lockMobile = useAppSelector((state) => state.preferences.lockMobile);
-
-  const setMobile = (val: boolean) => {
-    dispatch(setMobileState(val));
-  };
-
-  const setLockMobile = (val: boolean) => {
-    dispatch(setLockMobileState(val));
-  };
-
-  return {
-    mobile,
-    setMobile,
-    lockMobile,
-    setLockMobile,
-  };
-};

--- a/client/src/state/hooks/use_preferences.ts
+++ b/client/src/state/hooks/use_preferences.ts
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import { useAppDispatch, useAppSelector } from "../../hooks";
+import { 
+    PreferencesState, 
+    setLayout as setPreferencesLayout, 
+    setIsSavePreferences as setPreferencesIsSavePreferences,
+    getWindowDimensions,
+    AUTO_SWITCH_THRESHOLD
+} from "../preferences";
+
+
+const UsePreferences = () => {
+    const dispatch = useAppDispatch()
+    const [mobile, setMobile] = React.useState<boolean>()
+
+    const layout = useAppSelector((state) => state.preferences.layout);
+    const setLayout = (layout: PreferencesState["layout"]) => dispatch(setPreferencesLayout(layout))
+
+    const isSavePreferences = useAppSelector((state) => state.preferences.isSavePreferences);
+    const setIsSavePreferences = (isSave: boolean) => dispatch(setPreferencesIsSavePreferences(isSave))
+
+    const automaticallyAdjustLayout = () => {
+        const {width} = getWindowDimensions()
+        setMobile(width < AUTO_SWITCH_THRESHOLD)
+    }
+
+    React.useEffect(()=>{
+        if (layout === "auto"){
+          void automaticallyAdjustLayout()
+          window.addEventListener('resize', automaticallyAdjustLayout)
+    
+          return () => window.removeEventListener('resize', automaticallyAdjustLayout)
+        } else {
+          setMobile(layout === "mobile")
+        }
+    }, [layout])
+
+    return {mobile, layout, isSavePreferences, setLayout, setIsSavePreferences}
+} 
+
+export default UsePreferences;

--- a/client/src/state/local_storage.ts
+++ b/client/src/state/local_storage.ts
@@ -57,3 +57,12 @@ export function savePreferences(state: any) {
     // Ignore
   }
 }
+
+export function removePreferences() {
+  try {
+    localStorage.removeItem(PREFERENCES_KEY);
+  } catch (e) {
+    // Ignore
+  }
+}
+

--- a/client/src/state/preferences.ts
+++ b/client/src/state/preferences.ts
@@ -1,10 +1,10 @@
 import { createSlice } from "@reduxjs/toolkit";
 
-import { loadPreferences } from "./local_storage";
+import { loadPreferences, removePreferences, savePreferences } from "./local_storage";
 
-interface PreferencesState {
-  mobile: boolean;
-  lockMobile: boolean;
+export interface PreferencesState {
+  layout: "mobile" | "auto" | "desktop";
+  isSavePreferences: boolean;
 }
 
 export function getWindowDimensions() {
@@ -12,26 +12,25 @@ export function getWindowDimensions() {
   return {width, height}
 }
 
-const { width } = getWindowDimensions()
-
 export const AUTO_SWITCH_THRESHOLD = 800
 
-const initialState: PreferencesState = loadPreferences() ?? {
-    mobile: width < AUTO_SWITCH_THRESHOLD,
-    lockMobile: false
+const initialState: PreferencesState = loadPreferences() ??{
+    layout: "auto",
+    isSavePreferences: false
 }
 
 export const preferencesSlice = createSlice({
   name: "preferences",
   initialState,
   reducers: {
-    setMobile: (state, action) => {
-      state.mobile = action.payload;
+    setLayout: (state, action) => {
+      state.layout = action.payload;
     },
-    setLockMobile: (state, action) => {
-      state.lockMobile = action.payload;
+    setisSavePreferences: (state, action) => {
+      state.isSavePreferences = action.payload;
+      action.payload ? savePreferences(state) : removePreferences()
     },
   },
 });
 
-export const { setMobile, setLockMobile } = preferencesSlice.actions;
+export const { setLayout, setisSavePreferences } = preferencesSlice.actions;

--- a/client/src/state/preferences.ts
+++ b/client/src/state/preferences.ts
@@ -28,7 +28,6 @@ export const preferencesSlice = createSlice({
     },
     setisSavePreferences: (state, action) => {
       state.isSavePreferences = action.payload;
-      action.payload ? savePreferences(state) : removePreferences()
     },
   },
 });

--- a/client/src/state/preferences.ts
+++ b/client/src/state/preferences.ts
@@ -26,10 +26,10 @@ export const preferencesSlice = createSlice({
     setLayout: (state, action) => {
       state.layout = action.payload;
     },
-    setisSavePreferences: (state, action) => {
+    setIsSavePreferences: (state, action) => {
       state.isSavePreferences = action.payload;
     },
   },
 });
 
-export const { setLayout, setisSavePreferences } = preferencesSlice.actions;
+export const { setLayout, setIsSavePreferences } = preferencesSlice.actions;

--- a/client/src/state/store.ts
+++ b/client/src/state/store.ts
@@ -30,7 +30,7 @@ store.subscribe(
   debounce(() => {
     saveState(store.getState()[progressSlice.name]);
 
-    const preferencesState= store.getState()[preferencesSlice.name]
+    const preferencesState = store.getState()[preferencesSlice.name]
     preferencesState.isSavePreferences ? savePreferences(preferencesState) : removePreferences()
   }, 800)
 );

--- a/client/src/state/store.ts
+++ b/client/src/state/store.ts
@@ -8,7 +8,7 @@ import { connection } from '../connection'
 import { apiSlice } from './api'
 import { progressSlice } from './progress'
 import { preferencesSlice } from "./preferences"
-import { saveState, savePreferences } from "./local_storage";
+import { saveState, savePreferences, removePreferences} from "./local_storage";
 
 
 export const store = configureStore({
@@ -29,7 +29,9 @@ export const store = configureStore({
 store.subscribe(
   debounce(() => {
     saveState(store.getState()[progressSlice.name]);
-    savePreferences(store.getState()[preferencesSlice.name]);
+
+    const preferencesState= store.getState()[preferencesSlice.name]
+    preferencesState.isSavePreferences ? savePreferences(preferencesState) : removePreferences()
   }, 800)
 );
 


### PR DESCRIPTION
issues: https://github.com/leanprover-community/lean4game/issues/172

## Description
I modified the original logic about preferences. 

Now the ```mobile``` option will not appear on the page but will be replaced by ```layout```.

And I added the function of saving to the browser. If it is switched to true, the user's selection will be saved, otherwise it will be deleted.

## Known issues (Maybe it needs to be discussed)
1. I want to delete everything about ```mobile```,  and use ```layout``` entirely instead, and of course I would implicitly save the ```mobile``` device field in the preferences for the previous code without having to make too many changes(because it seems to me that their functions are somewhat duplicated.).


## Demonstration diagram
![image](https://github.com/leanprover-community/lean4game/assets/90966139/4bddcff8-4602-4f62-b220-12504a1c6cab)

