### PR TITLE
Minor: correct error in markdown

### DIFF
--- a/doc/publish_game.md
+++ b/doc/publish_game.md
@@ -1,6 +1,6 @@
 # Publishing games
 
-You can publish your game on the official (Lean Game Server)[https://adam.math.hhu.de] in a few simple
+You can publish your game on the official [Lean Game Server](https://adam.math.hhu.de) in a few simple
 steps.
 
 ## 1. Upload Game to github


### PR DESCRIPTION
Just spotted a minor error where `[]` and `()` were mixed up for a link.