### PR TITLE
Fix Bug with Environment Variables for Ports

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react-swc'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 import svgr from "vite-plugin-svgr"
 
+const backendPort = process.env.PORT || 8080;
+const clientPort = process.env.CLIENT_PORT || 3000;
+
 // https://vitejs.dev/config/
 export default defineConfig({
   //root: 'client/src',
@@ -32,20 +35,20 @@ export default defineConfig({
     exclude: ['games']
   },
   server: {
-    port: 3000,
+    port: Number(clientPort),
     proxy: {
       '/websocket': {
-        target: 'ws://localhost:8080',
+        target: `ws://localhost:${backendPort}`,
         ws: true
       },
       '/import': {
-        target: 'http://localhost:8080',
+        target: `http://localhost:${backendPort}`,
       },
       '/data': {
-        target: 'http://localhost:8080',
+        target: `http://localhost:${backendPort}`,
       },
       '/i18n': {
-        target: 'http://localhost:8080',
+        target: `http://localhost:${backendPort}`,
       },
     }
   },


### PR DESCRIPTION
Thanks for the awesome project! 
I'm working on deploying a game myself and encountered a bug related to port configuration. I've made a small change to fix it.

**Description:**
This PR updates the Vite server configuration to allow the setting of the client port using the environment variable `CLIENT_PORT`, with a default value of 3000. Additionally, it fixes a bug related to the `backendPort` configuration.

The code here:

https://github.com/leanprover-community/lean4game/blob/4ed0753bb06b12437152a6e1ebf2b55774878fe8/vite.config.ts#L38

Can results in the following error:

```bash
❯ export PORT=8082
❯ npm run start

> lean4-game@0.1.0 start
> concurrently -n server,client -c blue,green "npm run start_server" "npm run start_client"

[server] 
[server] > lean4-game@0.1.0 start_server
[server] > (cd server && lake build) && (cd relay && cross-env NODE_ENV=development nodemon -e mjs --exec "node ./index.mjs")
...
[server] Listening on 8082
[client] (node:17273) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
[client] (Use `node --trace-deprecation ...` to show where the warning was created)
[client] 3:55:28 PM [vite] http proxy error at /i18n/g/local/NNG4/en/Game.json:
[client] Error: connect ECONNREFUSED 127.0.0.1:8080
[client]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1606:16)
[client] 3:55:28 PM [vite] http proxy error at /data/g/local/NNG4/inventory.json:
[client] Error: connect ECONNREFUSED 127.0.0.1:8080
[client]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1606:16)
...
```

**Changes:**
- Modified `vite.config.js` to read the `CLIENT_PORT` environment variable for the client port.
- Corrected the `backendPort` configuration.

**Benefits:**
- Provides flexibility in configuring the development server port to avoid port conflicts.
