### PR TITLE
Environment Variable for Default Language Setting

### DIFF
--- a/client/src/state/preferences.ts
+++ b/client/src/state/preferences.ts
@@ -18,8 +18,8 @@ export const AUTO_SWITCH_THRESHOLD = 800
 const initialState: PreferencesState = loadPreferences() ??{
     layout: "auto",
     isSavePreferences: false,
-    language: "en",
-}
+    language: import.meta.env.VITE_CLIENT_DEFAULT_LANGUAGE || "en",
+};
 
 export const preferencesSlice = createSlice({
   name: "preferences",

--- a/doc/npm_scripts.md
+++ b/doc/npm_scripts.md
@@ -7,3 +7,13 @@ Internally, websocket requests to `ws://localhost:3000/websockets` will be forwa
 On the server side, the command will set up a docker image containing the Lean server. The two parts can be built separately using `npm run build_client` and `npm run build_server`.
 
 * `npm run production`: Start the project in production mode. This requires that the build script has been run. It will start a server on the port specified in the `PORT` environment variable or by default on `8080`. You can run on a specific port by running `PORT=80 npm run production`. The server will serve the files in `client/dist` via http and give access to the bubblewrapped Lean server via the web socket protocol.
+
+### Environment Variables
+
+The client and server ports, as well as the default language, can be configured using environment variables:
+
+* `PORT`: Sets the port for the backend server (default: `8080`).
+* `CLIENT_PORT`: Sets the port for the client server (default: `3000`).
+* `VITE_CLIENT_DEFAULT_LANGUAGE`: Sets the default language for the application (default: `en`).
+
+Ensure these environment variables are set appropriately in your environment to configure the project as needed.


### PR DESCRIPTION
This PR enables the use of an environment variable, `VITE_CLIENT_DEFAULT_LANGUAGE`, to set the default language for the application, enhancing deployment flexibility.

## Changes
- `preferences.ts` now reads the default language from `VITE_CLIENT_DEFAULT_LANGUAGE`.
- updated documentation to explain the setup of the environment variable.

The variable prefix `VITE_` is used as the discussion on [stackoverflow](https://stackoverflow.com/a/76285653/13390383).

Thanks for reviewing this update.