### PR TITLE
fix(relay): create logs directory before logging attempt

### DIFF
--- a/relay/index.mjs
+++ b/relay/index.mjs
@@ -45,16 +45,22 @@ const server = app
     const lang = req.params.lang
 
     const ip = anonymize(req.headers['x-forwarded-for'] || req.socket.remoteAddress)
-    const log = `${process.cwd()}/logs/game-access.log`
+    const log = path.join(process.cwd(), 'logs', 'game-access.log')
     const header = "date;anon-ip;game;lang\n"
     const data = `${new Date()};${ip};${owner}/${repo};${lang}\n`
 
-    fs.writeFile(log, header.concat(data), { flag: 'ax' }, (file_exists) => {
-	    if (file_exists) {
-		fs.appendFile(log, data, (err) => {
-		  if (err) console.log("Failed to append to log!")
-		});
-	    }
+    fs.mkdir(path.join(process.cwd(), 'logs'), { recursive: true }, (err) => {
+      if (err) console.log("Failed to create logs directory!")
+      else {
+        // 'ax' fails if the file already exists: https://nodejs.org/api/fs.html#file-system-flags
+        fs.writeFile(log, header.concat(data), { flag: 'ax' }, (file_exists) => {
+          if (file_exists) {
+            fs.appendFile(log, data, (err) => {
+              if (err) console.log(`Failed to append to log: ${err}`)
+            });
+          }
+        });
+      }
     });
 
     console.log(`[${new Date()}] ${ip} requested translation for ${owner}/${repo} in ${lang}`)


### PR DESCRIPTION
this also:
- uses the path.join API instead of direct path concatenation
- doesn't silently ignore the error created by appendFile