### PR TITLE
Stop trimming '!' and '?' from tactic name. Fixes #299

### DIFF
--- a/server/GameServer/FileWorker.lean
+++ b/server/GameServer/FileWorker.lean
@@ -127,7 +127,6 @@ partial def findForbiddenTactics (inputCtx : Parser.InputContext) (workerState :
     -- Ignore syntax elements that do not start with a letter or are listed above.
     if 0 < val.length ∧ val.data[0]!.isAlpha ∧ not (allowed.contains val) then
       -- Treat `simp?` and `simp!` like `simp`
-      let val := val.dropRightWhile (fun c => c == '!' || c == '?')
       match levelInfo.tactics.find? (·.name.toString == val) with
       | none =>
         -- Tactic will never be introduced in the game.

--- a/server/GameServer/Inventory.lean
+++ b/server/GameServer/Inventory.lean
@@ -123,7 +123,6 @@ partial def collectUsedInventory (stx : Syntax) (acc : UsedInventory := {}) : Co
     -- and ignore some standard keywords
     let allowed := GameServer.ALLOWED_KEYWORDS
     if 0 < val.length ∧ val.data[0]!.isAlpha ∧ not (allowed.contains val) then
-      let val := val.dropRightWhile (fun c => c == '!' || c == '?') -- treat `simp?` and `simp!` like `simp`
       return {acc with tactics := acc.tactics.insert val}
     else
       return acc


### PR DESCRIPTION
Stop trimming '!' and '?' from tactic name. Fixes #299. I have used `main` as the base branch since I don't know how to test on `dev` since the editor is not working on `dev`.