### PR TITLE
Allow customized single game name in devcontainer

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -14,11 +14,12 @@ import './i18n';
 
 
 // If `VITE_LEAN4GAME_SINGLE` is set to true, then `/` should be redirected to
-// `/g/local/game`. This is used for the devcontainer setup
-let single_game = (import.meta.env.VITE_LEAN4GAME_SINGLE == "true")
+// `/g/local/game` or customized VITE_LEAN4GAME_SINGLE_NAME. This is used for the devcontainer setup
+let single_game = (import.meta.env.VITE_LEAN4GAME_SINGLE === "true")
+let single_game_name = (import.meta.env.VITE_LEAN4GAME_SINGLE_NAME === undefined) ? "game" : import.meta.env.VITE_LEAN4GAME_SINGLE_NAME
 let root_object: RouteObject = single_game ? {
   path: "/",
-  loader: () => redirect("/g/local/game")
+  loader: () => redirect("/g/local/${ single_game_name }")
 } : {
   path: "/",
   element: <App />,


### PR DESCRIPTION
Currently the devcontainer at https://github.com/hhu-adam/GameSkeleton/ seems to not be working, so I'm working on a refactor at https://github.com/hhu-adam/GameSkeleton/pull/7

Part of the refactor is to simplify the codespace scaffolding to prefer convention over configuration. This PR would allow for the local game to be in a directory named the same as the repository (which is the default) by setting `VITE_LEAN4GAME_SINGLE_NAME` while maintaining current behavior for backwards compatibility.