### PR TITLE
fix: Game uses leanOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ server/.lake
 logs/
 relay/prev_cpu_metric
 test.ecosystem.config.cjs
+cypress/screenshots

--- a/cypress/TestGame/Game/Metadata.lean
+++ b/cypress/TestGame/Game/Metadata.lean
@@ -1,1 +1,1 @@
-import GameServer.Commands
+import GameServer

--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -18,7 +18,7 @@ is to provide the lean commands which are used when creating a game. These are l
 
 Games need the "server" as a lake-dependency, which is done in the game's lakefile.
 
-A game imports `GameServer.Commands` which provides to all the API required to
+A game imports `GameServer` which provides to all the API required to
 create a game.
 
 In particular the lean command `MakeGame` compiles the entire game. Static information is

--- a/doc/create_game.md
+++ b/doc/create_game.md
@@ -55,7 +55,7 @@ A minimal level file looks like the following. There are many options to add, wh
 into in a later section
 
 ```lean
-import GameServer.Commands
+import GameServer
 
 World "MyWorld"
 Level 1
@@ -109,8 +109,8 @@ introduced anywhere.
 
 ## 5. Refactoring an existing world
 
-The [GameSkeleton template](https://github.com/hhu-adam/GameSkeleton)  contains a bash script `sofi.sh` 
-(`s`ort `o`ut `f`ilnames and `i`mports), 
+The [GameSkeleton template](https://github.com/hhu-adam/GameSkeleton)  contains a bash script `sofi.sh`
+(`s`ort `o`ut `f`ilnames and `i`mports),
 which can help restructure existing worlds, for example if you want to reorder or rename existing levels,
 or add additional levels in the middle.  Say, for example, you have an “Arithmetic World” in the
 folder

--- a/server/GameServer.lean
+++ b/server/GameServer.lean
@@ -1,2 +1,17 @@
+import GameServer.AbstractCtx
+import GameServer.Commands
+import GameServer.EnvExtensions
 import GameServer.Game
+import GameServer.Graph
+import GameServer.Helpers.PrettyPrinter
+import GameServer.Helpers
+import GameServer.Hints
+import GameServer.InteractiveGoal
+import GameServer.Inventory
+import GameServer.Options
+import GameServer.RpcHandlers
 import GameServer.Runner
+import GameServer.SaveData
+import GameServer.Structures
+import GameServer.Tactic.LetIntros
+import GameServer.Utils

--- a/server/lakefile.lean
+++ b/server/lakefile.lean
@@ -13,3 +13,6 @@ require importGraph from git "https://github.com/leanprover-community/import-gra
 
 @[default_target]
 lean_lib GameServer
+
+@[test_driver]
+lean_lib test

--- a/server/test.lean
+++ b/server/test.lean
@@ -1,0 +1,4 @@
+import test.findLoop
+import test.let_intros
+import test.tactic_docstring_test
+-- import test.test_statement

--- a/server/test/findLoop.lean
+++ b/server/test/findLoop.lean
@@ -1,18 +1,20 @@
-import GameServer.Commands
+import GameServer.Helpers
+import GameServer.Utils
 
-open Lean
+open GameServer Lean Std
 
 -- E → A → B → C → A and
 -- F → G → F
 open HashMap in
 def testArrows : HashMap Name (HashSet Name) :=
-  ofList [("a", (HashSet.empty.insert "b": HashSet Name).insert "d"),
-          ("b", (HashSet.empty.insert "c": HashSet Name)),
-          ("c", (HashSet.empty.insert "a": HashSet Name)),
+  ofList [("a", (HashSet.emptyWithCapacity.insert "b": HashSet Name).insert "d"),
+          ("b", (HashSet.emptyWithCapacity.insert "c": HashSet Name)),
+          ("c", (HashSet.emptyWithCapacity.insert "a": HashSet Name)),
           ("d", {}),
-          ("f", (HashSet.empty.insert "g": HashSet Name)),
-          ("g", (HashSet.empty.insert "f": HashSet Name)),
-          ("e", (HashSet.empty.insert "a": HashSet Name).insert "f")]
+          ("f", (HashSet.emptyWithCapacity.insert "g": HashSet Name)),
+          ("g", (HashSet.emptyWithCapacity.insert "f": HashSet Name)),
+          ("e", (HashSet.emptyWithCapacity.insert "a": HashSet Name).insert "f")]
 
--- some permutation of ``[`c, `a, `b]`` or ``[`f, `g]``
+/-- info: [`a, `b, `c] -/
+#guard_msgs in
 #eval findLoops testArrows

--- a/server/test/test_statement.lean
+++ b/server/test/test_statement.lean
@@ -1,5 +1,4 @@
-import GameServer.Commands
---import
+import GameServer
 
 Game "Test"
 World "TestW"


### PR DESCRIPTION
The language server only applies the `leanOptions` specified in the project's lakefile if the URI of the opened file actually exists on disk. (See also comment in `lean4web/Projects/README.md`). Therefore we modify the URI in the proxy between client and server.

Further:
- Import everything from `GameServer.lean` and instruct games to `import GameServer`.
- Turn existing tests into a test-driver, which can be executed with `lake test`