### PR TITLE
Fix: put everything inside `GameServer` namespace

### DIFF
--- a/server/GameServer/AbstractCtx.lean
+++ b/server/GameServer/AbstractCtx.lean
@@ -1,6 +1,8 @@
 import Lean
 import GameServer.Utils
 
+namespace GameServer
+
 section AbstractCtx
 open Lean
 open Meta

--- a/server/GameServer/Commands.lean
+++ b/server/GameServer/Commands.lean
@@ -9,7 +9,7 @@ import I18n
 
 open Lean Meta Elab Command Std
 
-open GameServer
+namespace GameServer
 
 set_option autoImplicit false
 

--- a/server/GameServer/EnvExtensions.lean
+++ b/server/GameServer/EnvExtensions.lean
@@ -2,7 +2,9 @@ import GameServer.AbstractCtx
 import GameServer.Graph
 import GameServer.Hints
 
-open GameServer Std
+namespace GameServer
+
+open Std
 
 -- TODO: Is there a better place?
 /-- Keywords that the server should not consider as tactics. -/

--- a/server/GameServer/Graph.lean
+++ b/server/GameServer/Graph.lean
@@ -1,6 +1,8 @@
 import Lean
 import Std.Data.HashMap.Basic
 
+namespace GameServer
+
 open Lean Std
 
 /-! ## Graph -/

--- a/server/GameServer/Inventory.lean
+++ b/server/GameServer/Inventory.lean
@@ -1,6 +1,8 @@
 import Lean
 import GameServer.EnvExtensions
 
+namespace GameServer
+
 open Lean Elab Command
 
 /-- Copied from `Mathlib.Tactic.HelpCmd`.

--- a/server/GameServer/Runner.lean
+++ b/server/GameServer/Runner.lean
@@ -3,6 +3,7 @@ import GameServer.RpcHandlers
 import GameServer.SaveData
 import GameServer.Tactic.LetIntros
 
+namespace GameServer
 
 open Lean Meta Elab Command
 

--- a/server/GameServer/SaveData.lean
+++ b/server/GameServer/SaveData.lean
@@ -1,6 +1,8 @@
 import GameServer.EnvExtensions
 import I18n
 
+namespace GameServer
+
 open Lean Meta Elab Command Std
 
 /-! ## Copy images -/

--- a/server/GameServer/Utils.lean
+++ b/server/GameServer/Utils.lean
@@ -1,5 +1,7 @@
 import Lean
 
+namespace GameServer
+
 open Lean Meta Elab Tactic Command
 
 syntax showOptArg := atomic(" (" (&"strict" <|> &"verbose") " := " withoutPosition(term) ")")

--- a/server/lake-manifest.json
+++ b/server/lake-manifest.json
@@ -15,7 +15,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "7dc27b87606f94ad0931a09f63330028d653d325",
+   "rev": "443d04399e9df1e47ae8a70b558a8fa049ab9d8b",
    "name": "i18n",
    "manifestFile": "lake-manifest.json",
    "inputRev": "v4.21.0",


### PR DESCRIPTION
@matlorr observed that mathlib provides `_root_.Graph` which conflicted with our `_root_.Graph`. Therefore we prefix everything in our project with `GameServer.`