### PR TITLE
fix: add missing translation of level intro on mobile

### DIFF
--- a/client/src/components/button.tsx
+++ b/client/src/components/button.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { RefObject } from 'react';
 import { Link, LinkProps } from "react-router-dom";
 
 export interface ButtonProps extends LinkProps {
@@ -6,7 +7,7 @@ export interface ButtonProps extends LinkProps {
   inverted?: string // Apparently "inverted" in DOM cannot be `boolean` but must be `inverted`
 }
 
-const Button = React.forwardRef((props: ButtonProps, ref: any) => {
+const Button = React.forwardRef<HTMLAnchorElement, ButtonProps>((props, ref) => {
   if (props.disabled) {
     return <span ref={ref} className={`btn btn-disabled ${props.inverted === "true" ? 'btn-inverted' : ''}`} {...props}>{props.children}</span>
   } else {

--- a/client/src/components/infoview/main.tsx
+++ b/client/src/components/infoview/main.tsx
@@ -34,7 +34,7 @@ import { Button } from '../button';
 import { CircularProgress } from '@mui/material';
 import { GameHint, InteractiveGoalsWithHints, ProofState } from './rpc_api';
 import { store } from '../../state/store';
-import { Hints, MoreHelpButton, filterHints } from '../hints';
+import { Hint, Hints, MoreHelpButton, filterHints } from '../hints';
 import { DocumentPosition } from '../../../../node_modules/lean4-infoview/src/infoview/util';
 import { DiagnosticSeverity } from 'vscode-languageclient';
 import { useTranslation } from 'react-i18next';
@@ -507,6 +507,8 @@ export function TypewriterInterface({props}) {
     }
   })
 
+  let introText: Array<string> = t(props?.data?.introduction, {ns: gameId}).split(/\n(\s*\n)+/)
+
   return <div className="typewriter-interface">
     <RpcContext.Provider value={rpcSess}>
     <div className="content">
@@ -560,9 +562,11 @@ export function TypewriterInterface({props}) {
                   <Command proof={proof} i={i} deleteProof={deleteProof(i)} />
                   <Errors errors={step.diags} typewriterMode={true} />
                   {mobile && i == 0 && props.data?.introduction &&
-                    <div className={`message information step-0${selectedStep === 0 ? ' selected' : ''}`} onClick={toggleSelectStep(0)}>
-                      <Markdown>{props.data?.introduction}</Markdown>
-                    </div>
+                    introText?.filter(it => it.trim()).map(((it, i) =>
+                      // Show the level's intro text as hints, too
+                      <Hint key={`intro-p-${i}`}
+                        hint={{text: it, hidden: false, rawText: it, varNames: []}} step={0} selected={selectedStep} toggleSelection={toggleSelectStep(0)} />
+                    ))
                   }
                   {mobile &&
                     <Hints key={`hints-${i}`}

--- a/client/src/components/level.tsx
+++ b/client/src/components/level.tsx
@@ -137,10 +137,10 @@ function ChatPanel({lastLevel, visible = true}) {
 
   return <div className={`chat-panel ${visible ? '' : 'hidden'}`}>
     <div ref={chatRef} className="chat">
-      {introText?.filter(t => t.trim()).map(((t, i) =>
+      {introText?.filter(it => it.trim()).map(((it, i) =>
         // Show the level's intro text as hints, too
         <Hint key={`intro-p-${i}`}
-          hint={{text: t, hidden: false, rawText: t, varNames: []}} step={0} selected={selectedStep} toggleSelection={toggleSelection(0)} />
+          hint={{text: it, hidden: false, rawText: it, varNames: []}} step={0} selected={selectedStep} toggleSelection={toggleSelection(0)} />
       ))}
       {proof?.steps.map((step, i) => {
         let filteredHints = filterHints(step.goals[0]?.hints, proof?.steps[i-1]?.goals[0]?.hints)

--- a/client/src/components/level.tsx
+++ b/client/src/components/level.tsx
@@ -128,7 +128,7 @@ function ChatPanel({lastLevel, visible = true}) {
 
   let introText: Array<string> = t(level?.data?.introduction, {ns: gameId}).split(/\n(\s*\n)+/)
 
-  const focusRef = useRef()
+  const focusRef = useRef<HTMLAnchorElement>()
   useEffect(() => {
    if (proof?.completed) {
      focusRef.current.focus()
@@ -442,7 +442,7 @@ function IntroductionPanel({gameInfo}) {
 
   let text: Array<string> = t(gameInfo.data?.worlds.nodes[worldId].introduction, {ns: gameId}).split(/\n(\s*\n)+/)
 
-  const focusRef = useRef()
+  const focusRef = useRef<HTMLAnchorElement>()
   useEffect(() => {
    focusRef.current?.focus()
   }, [])


### PR DESCRIPTION
On mobile, the level introduction was not translated and not split. Align the behaviour with the desktop behaviour. Moreover, fix some TS-errors