### PR TITLE
Add history navigation to typewriter input

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -8,7 +8,8 @@ import '@fontsource/roboto/700.css';
 
 import './css/reset.css';
 import './css/app.css';
-import { PreferencesContext, WorldLevelIdContext} from './components/infoview/context';
+import { HistoryContext, PreferencesContext, WorldLevelIdContext} from './components/infoview/context';
+import { NO_HISTORY_INDEX } from './components/infoview/typewriter';
 import UsePreferences from "./state/hooks/use_preferences"
 import i18n from './i18n';
 import { Popup } from './components/popup/popup';
@@ -24,6 +25,9 @@ function App() {
 
   const {mobile, layout, isSavePreferences, language, isSuggestionsMobileMode, setLayout, setIsSavePreferences, setLanguage, setIsSuggestionsMobileMode} = UsePreferences()
 
+  // Typewriter history state (persists across game levels)
+  const [history, setHistory] = React.useState<string[]>([])
+
   React.useEffect(() => {
     i18n.changeLanguage(language)
   }, [language])
@@ -33,10 +37,12 @@ function App() {
       <GameIdContext.Provider value={gameId}>
           <WorldLevelIdContext.Provider value={{worldId, levelId}}>
           <PreferencesContext.Provider value={{mobile, layout, isSavePreferences, language, isSuggestionsMobileMode, setLayout, setIsSavePreferences, setLanguage, setIsSuggestionsMobileMode}}>
-            <React.Suspense>
-              <Outlet />
-            </React.Suspense>
-            <Popup />
+            <HistoryContext.Provider value={{history, setHistory}}>
+              <React.Suspense>
+                <Outlet />
+              </React.Suspense>
+              <Popup />
+            </HistoryContext.Provider>
           </PreferencesContext.Provider>
           </WorldLevelIdContext.Provider>
       </GameIdContext.Provider>

--- a/client/src/components/infoview/context.ts
+++ b/client/src/components/infoview/context.ts
@@ -7,6 +7,7 @@ import { InteractiveDiagnostic } from '@leanprover/infoview-api';
 import { Diagnostic } from 'vscode-languageserver-types'
 import { GameHint, InteractiveGoal, InteractiveTermGoal,InteractiveGoalsWithHints, ProofState } from './rpc_api';
 import { PreferencesState } from '../../state/preferences';
+import { NO_HISTORY_INDEX } from './typewriter';
 
 export const MonacoEditorContext = React.createContext<monaco.editor.IStandaloneCodeEditor>(
   null as any)
@@ -126,6 +127,14 @@ export const DeletedChatContext = React.createContext<{
   setShowHelp: () => {}
 })
 
+export const HistoryContext = React.createContext<{
+  history: string[],
+  setHistory: React.Dispatch<React.SetStateAction<string[]>>,
+}>({
+  history: [],
+  setHistory: () => {},
+});
+
 export const InputModeContext = React.createContext<{
   typewriterMode: boolean,
   setTypewriterMode: React.Dispatch<React.SetStateAction<boolean>>,
@@ -133,6 +142,10 @@ export const InputModeContext = React.createContext<{
   setTypewriterInput: React.Dispatch<React.SetStateAction<string>>,
   lockEditorMode: boolean,
   setLockEditorMode: React.Dispatch<React.SetStateAction<boolean>>,
+  historyIndex: number,
+  setHistoryIndex: React.Dispatch<React.SetStateAction<number>>,
+  tempInput: string,
+  setTempInput: React.Dispatch<React.SetStateAction<string>>,
 }>({
   typewriterMode: true,
   setTypewriterMode: () => {},
@@ -140,6 +153,10 @@ export const InputModeContext = React.createContext<{
   setTypewriterInput: () => {},
   lockEditorMode: false,
   setLockEditorMode: () => {},
+  historyIndex: NO_HISTORY_INDEX,
+  setHistoryIndex: () => {},
+  tempInput: "",
+  setTempInput: () => {},
 });
 
 

--- a/client/src/components/level.tsx
+++ b/client/src/components/level.tsx
@@ -26,7 +26,7 @@ import { changedSelection, codeEdited, selectCode, selectSelections, selectCompl
 import { store } from '../state/store'
 import { Button } from './button'
 import { Markdown } from './markdown'
-import { hasInteractiveErrors } from './infoview/typewriter'
+import { NO_HISTORY_INDEX, hasInteractiveErrors } from './infoview/typewriter'
 import { DeletedChatContext, InputModeContext, PreferencesContext, MonacoEditorContext,
   ProofContext, SelectionContext, WorldLevelIdContext } from './infoview/context'
 import { DualEditor } from './infoview/main'
@@ -233,9 +233,10 @@ function PlayableLevel() {
   // Only for mobile layout
   const [pageNumber, setPageNumber] = useState(0)
 
-  // set to true to prevent switching between typewriter and editor
   const [lockEditorMode, setLockEditorMode] = useState(false)
   const [typewriterInput, setTypewriterInput] = useState("")
+  const [tempInput, setTempInput] = useState("")
+  const [historyIndex, setHistoryIndex] = useState(NO_HISTORY_INDEX)
   const lastLevel = levelId >= gameInfo.data?.worldSize[worldId]
 
   // When clicking on an inventory item, the inventory is overlayed by the item's doc.
@@ -396,7 +397,7 @@ function PlayableLevel() {
     <div style={level.isLoading ? null : {display: "none"}} className="app-content loading"><CircularProgress /></div>
     <DeletedChatContext.Provider value={{deletedChat, setDeletedChat, showHelp, setShowHelp}}>
       <SelectionContext.Provider value={{selectedStep, setSelectedStep}}>
-        <InputModeContext.Provider value={{typewriterMode, setTypewriterMode, typewriterInput, setTypewriterInput, lockEditorMode, setLockEditorMode}}>
+        <InputModeContext.Provider value={{typewriterMode, setTypewriterMode, typewriterInput, setTypewriterInput, lockEditorMode, setLockEditorMode, historyIndex, setHistoryIndex, tempInput, setTempInput}}>
           <ProofContext.Provider value={{proof, setProof, interimDiags, setInterimDiags, crashed: isCrashed, setCrashed: setIsCrashed}}>
             <EditorContext.Provider value={editorConnection}>
               <MonacoEditorContext.Provider value={editor}>


### PR DESCRIPTION
This lets the user navigate between previously used lines, in the typewriter input, à la readline.

This history persists between levels.