### PR TITLE
CI: Add Dependabot support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
[Dependabot](https://github.com/dependabot) is a GitHub-native bot that opens PRs to keep dependencies up to date. This adds a configuration file so that, once a week, Dependabot will open a single grouped PR bundling all available minor and patch updates for npm dependencies, and another for GitHub Actions versions.

Major version bumps are ignored and still need to be done manually. Lean/Lake dependencies are also not supported by Dependabot and remain manual.