### PR TITLE
Fix: drop forced language for Robo game

### DIFF
--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -10,12 +10,13 @@ i18n
     backend: {
       // > see https://github.com/i18next/i18next-http-backend
       loadPath: function(lngs, namespaces: Array<string>) {
-        const lng = namespaces[0] === "g/hhu-adam/robo" ? "de" : lngs[0];
+        const lng = lngs[0];
+        const ns = namespaces[0]
 
-        if (namespaces[0].startsWith("g/")) {
-          return `/i18n/${namespaces[0]}/${lng}/Game.json`;
+        if (ns.startsWith("g/")) {
+          return `/i18n/${ns}/${lng}/Game.json`;
         } else {
-          return `/locales/${lng}/${namespaces[0]}.json`;
+          return `/locales/${lng}/${ns}.json`;
         }
       }
     },


### PR DESCRIPTION
We forced German language for the Robo game to be able to deploy the game with partial English translation. Now that this is completed we remove it again.