### PR TITLE
Fix: empty response if game resources not found

### DIFF
--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -53,7 +53,16 @@ const server = app
 
     const filename = req.params[0];
     req.url = filename;
-    express.static(path.join(gameManager.getGameDir(owner,repo),".i18n",lang))(req, res, next);
+    const staticHandler = express.static(
+      path.join(gameManager.getGameDir(owner, repo), ".i18n", lang),
+      { fallthrough: true }
+    );
+    staticHandler(req, res, (err) => {
+      if (err) return next(err);
+      // if missing, return empty json instead
+      res.setHeader("Content-Type", "application/json");
+      res.status(200).send("{}");
+    });
   })
   .use('/data/g/:owner/:repo/*', (req, res, next) => {
     const owner = req.params.owner;
@@ -61,7 +70,16 @@ const server = app
     const filename = req.params[0];
     req.url = filename;
     console.debug(gameManager.getGameDir(owner,repo))
-    express.static(path.join(gameManager.getGameDir(owner,repo),".lake","gamedata"))(req, res, next);
+    const staticHandler = express.static(
+      path.join(gameManager.getGameDir(owner,repo),".lake","gamedata"),
+      { fallthrough: true }
+    );
+    staticHandler(req, res, (err) => {
+      if (err) return next(err);
+      // if missing, return empty json instead
+      res.setHeader("Content-Type", "application/json");
+      res.status(200).send("{}");
+    });
   })
   .use('/data/stats', (req, res, next) => {
     // TODO: this throws on Windows


### PR DESCRIPTION
Featured games as well as translation files might be missing. Create empty responses in this case to avoid console & network errors being displayed to the client.

Closes: #452