### PR TITLE
Don't clear proof state when switching to editor mode

### DIFF
--- a/client/src/components/level.tsx
+++ b/client/src/components/level.tsx
@@ -435,11 +435,12 @@ function PlayableLevel() {
   }, [gameId, worldId, levelId])
 
   useEffect(() => {
-    const model = leanMonacoEditor?.editor?.getModel()
-    if (!(typewriterMode) && model) {
+    const editor = leanMonacoEditor?.editor;
+    const selection = editor?.getSelection();
+    if (!typewriterMode && editor && selection) {
       // Delete last input attempt from command line
       leanMonacoEditor?.editor.executeEdits("typewriter", [{
-        range: model.getFullModelRange(),
+        range: selection,
         text: "",
         forceMoveMarkers: false
       }]);

--- a/client/src/components/level.tsx
+++ b/client/src/components/level.tsx
@@ -439,7 +439,7 @@ function PlayableLevel() {
     const selection = editor?.getSelection();
     if (!typewriterMode && editor && selection) {
       // Delete last input attempt from command line
-      leanMonacoEditor?.editor.executeEdits("typewriter", [{
+      editor.executeEdits("typewriter", [{
         range: selection,
         text: "",
         forceMoveMarkers: false


### PR DESCRIPTION
Currently, there is a bug where switching between typewriter mode and editor mode deletes the entire proof.  After doing some digging, it seems that the applied range was accidentally changed to `getFullModelRange()` (the whole text) from `getSelection()` (the last line) as part of 4ff7c98aa1337a4a0dee4cd7b1c45561515f3ded.  