### PR TITLE
Report errors from inline tactic usage

### DIFF
--- a/server/GameServer/RpcHandlers.lean
+++ b/server/GameServer/RpcHandlers.lean
@@ -144,9 +144,13 @@ def findHints (goal : MVarId) (level : GameLevel) : MetaM (Array GameHint) := do
 
 def filterUnsolvedGoal (a : Array InteractiveDiagnostic) :
     Array InteractiveDiagnostic :=
-  a.filter (fun d => match d.message with
-  | .append ⟨(.tag (.expr (.text x)) _) :: _⟩ => x != "unsolved goals"
-  | _ => true)
+  a.filter (fun d =>
+    if let .append ⟨(.tag (.expr (.text "unsolved goals")) _) :: _⟩ := d.message
+    -- Start and end being the same indicates this diagnostic is for the top
+    -- level definition, not something entered by the user so should be ignored
+    then d.range.start != d.range.end
+    else true
+  )
 
 -- TODO: no need to have `RequestM`, just anything where `mut` works
 /-- Add custom diagnostics about whether the level is completed. -/


### PR DESCRIPTION
If you have a one line proof where a tactic fails while working in typewriter mode, then the user receives no feedback that the proof has failed.  As an example, entering `have h12: 1 = 2 := by ring_nf` displays no error messages despite obviously failing.   The underlying issue is we are not returning any errors with the message "unsolved goals" to prevent showing the overall error for the incomplete exercise, but this is the same error reported in the above case.  Upon deeper investigation, it seems the overall error will always be reported with an empty range while the other cases have some text attributed to them.  This allowed me to update the filter to only capture this case and correctly show errors for the inline case.