### PR TITLE
provide default path for cpu_usage.py in stats.sh

### DIFF
--- a/relay/scripts/stats.sh
+++ b/relay/scripts/stats.sh
@@ -3,7 +3,7 @@
 # Load python interpreter
 python=/usr/bin/python3
 # Load python script
-cpu_usage=$CPU_SCRIPT
+cpu_usage=${CPU_SCRIPT:-$(dirname "$0")/cpu_usage.py}
 # Execute python script
 cpu=$($python $cpu_usage)
 # Calculate memory usage by computing (used memory - cached/buffer memory) divided by total memory


### PR DESCRIPTION
The stats script was hanging when the CPU_SCRIPT environment variable was not set, because python3 was being invoked without arguments. This adds a default fallback to the local cpu_usage.py script.

When I ran the server according to https://github.com/leanprover-community/lean4game/blob/main/doc/running_locally.md#manual-installation, opened http://localhost:3000/, and accessed `http://localhost:3000/data/stats`, it did not return a response.
This was because the default value for `CPU_SCRIPT` was empty, causing `python3` to run without any arguments and remain in a non-terminating state.