### PR TITLE
fix: keep translations marked inside a hint

### DIFF
--- a/server/GameServer/Tactic/Branch.lean
+++ b/server/GameServer/Tactic/Branch.lean
@@ -1,8 +1,9 @@
 import GameServer.EnvExtensions
+import I18n.EnvExtension
 
 namespace GameServer.Tactic
 
-open Lean Elab
+open Lean Elab I18n
 
 /-- This tactic allows us to execute an alternative sequence of tactics, but without affecting the
 proof state. We use it to define Hints for alternative proof methods or dead ends. -/
@@ -18,10 +19,16 @@ elab (name := Branch) "Branch" t:tacticSeq : tactic => do
   else
     trace[debug] "This branch leaves open goals."
 
+  -- data to keep
   let msgs ← Core.getMessageLog
-  let gameExtState := gameExt.getState (← getEnv)
+  let env ← getEnv
+  let gameExtState := gameExt.getState env
+  let translationExtState := untranslatedKeysExt.getState env
 
+  -- restore state
   b.restore
 
+  -- add data which should be kept
   Core.setMessageLog msgs
   modifyEnv (fun env => gameExt.setState env gameExtState)
+  modifyEnv (fun env => untranslatedKeysExt.setState env translationExtState)


### PR DESCRIPTION
Explicitly add translation keys from hints inside branches to the env extension after the environment has been restored.

- Closes: hhu-adam/lean-i18n/issues/28