### PR TITLE
fix: store world intro being read in game progress

### DIFF
--- a/client/src/components/level.tsx
+++ b/client/src/components/level.tsx
@@ -35,6 +35,7 @@ import { gameInfoAtom, levelInfoAtom } from '../store/query-atoms'
 import { deletedChatAtom, helpAtom, selectedStepAtom } from '../store/chat-atoms'
 import { inventoryOverviewAtom } from '../store/inventory-atoms'
 import { mobileAtom } from '../store/preferences-atoms'
+import { readWorldIntroAtom } from '../store/progress-atoms'
 
 const reconfigureLeanMonacoClient = async (leanMonaco: LeanMonaco, options: LeanMonacoOptions) => {
   const maybeLeanMonaco = leanMonaco as unknown as {
@@ -550,6 +551,7 @@ function IntroductionPanel() {
   const [worldId] = useAtom(worldIdAtom)
   const [{ data: gameInfo }] = useAtom(gameInfoAtom)
   const [, navigateToLevel] = useAtom(levelIdAtom)
+  const [, readWorldIntro] = useAtom(readWorldIntroAtom)
 
   const [mobile] = useAtom(mobileAtom)
 
@@ -572,7 +574,7 @@ function IntroductionPanel() {
         <Button onClick={() => {if (gameId) navigateToGame(gameId)}}>
           <FontAwesomeIcon icon={faHome} />
           </Button> :
-        <Button ref={focusRef} onClick={() => navigateToLevel(1)}>
+        <Button ref={focusRef} onClick={() => {readWorldIntro(); navigateToLevel(1)}}>
           {t("Start")}&nbsp;<FontAwesomeIcon icon={faArrowRight} />
         </Button>
       }

--- a/client/src/components/world_tree.tsx
+++ b/client/src/components/world_tree.tsx
@@ -16,7 +16,7 @@ import { gameIdAtom, navigateAcrossWorldsAtom } from '../store/location-atoms'
 import { difficultyAtom } from '../store/progress-atoms'
 import { gameInfoAtom } from '../store/query-atoms'
 import { mobileAtom } from '../store/preferences-atoms'
-import { levelCompletedAtomFamily, worldCompletedAtom, worldDependenciesCompletedAtomFamily } from '../store/world-tree-atoms'
+import { firstIncompleteLevelAtomFamily, levelCompletedAtomFamily, worldCompletedAtom, worldDependenciesCompletedAtomFamily, worldProgressAtomFamily } from '../store/world-tree-atoms'
 
 // Settings for the world tree
 cytoscape.use( klay )
@@ -54,6 +54,7 @@ export function LevelIcon({ world, level, position }:
   const [difficulty] = useAtom(difficultyAtom)
   const [levelUnlocked] = useAtom(levelCompletedAtomFamily(`${world}:${level-1}`))
   const [worldUnlocked] = useAtom(worldDependenciesCompletedAtomFamily(world))
+  const [worldProgress] = useAtom(worldProgressAtomFamily(world))
   const [completed] = useAtom(levelCompletedAtomFamily(`${world}:${level}`))
 
   const unlocked = level <= 1 ? worldUnlocked && levelUnlocked : levelUnlocked
@@ -89,8 +90,14 @@ export function LevelIcon({ world, level, position }:
     // spiraling case
     s * position.y - Math.cos(level * betaSpiral(level)) * (R + 2*r*(level-1)/(NSPIRAL+1))
 
+  // Show world intro if it hasn't been read so far
+  let targetLevel = level
+  if (level <= 1) {
+    targetLevel = (worldProgress?.readIntro) ? 1 : 0
+  }
+
   return (
-    <a onClick={() => {if (!levelDisabled) navigateAcrossWorlds(world, level == 1 ? 0 : level)}}
+    <a onClick={() => {if (!levelDisabled) navigateAcrossWorlds(world, targetLevel)}}
         className={`level${levelDisabled ? ' disabled' : ''}`}>
       <circle fill={completed ? lightgreen : unlocked? blue : lightgrey} cx={x} cy={y} r={r} />
       <foreignObject className="level-title-wrapper" x={x} y={y}
@@ -118,6 +125,7 @@ export function WorldIcon({world, title, position}:
   const [unlocked] = useAtom(worldDependenciesCompletedAtomFamily(world))
   const [completed] = useAtom(worldCompletedAtom(world))
   const worldDisabled = (difficulty >= 2 && !(unlocked || completed))
+  const [firstUncompleted] = useAtom(firstIncompleteLevelAtomFamily(world))
   const [, navigateAcrossWorlds] = useAtom(navigateAcrossWorldsAtom)
 
   // See level icons. Match radius computed there minus `1.2*r`
@@ -131,7 +139,7 @@ export function WorldIcon({world, title, position}:
   let labelOffset = R + 2.5 * r
 
   return <a
-      onClick={() => {if (!worldDisabled) navigateAcrossWorlds(world, 0)}}
+      onClick={() => {if (!worldDisabled) navigateAcrossWorlds(world, firstUncompleted)}}
       className={`world${worldDisabled ? ' disabled' : ''}`}>
     <circle className="world-circle" cx={s*position.x} cy={s*position.y} r={R}
         fill={completed ? green : unlocked ? blue : grey}/>

--- a/client/src/store/progress-atoms.ts
+++ b/client/src/store/progress-atoms.ts
@@ -2,6 +2,7 @@ import { atomWithStorage, createJSONStorage } from "jotai/utils";
 import { GameProgress, LevelProgress, Progress, WorldProgress, Selection, DEFAULT_DIFFICULTY } from "./progress-types";
 import { gameIdAtom, levelIdAtom, worldIdAtom } from "./location-atoms";
 import { atom } from "jotai";
+import { levelProgressAtomFamily } from "./world-tree-atoms";
 
 /**
  * The player's progress is stored in local storage under `game_progress`.
@@ -122,6 +123,12 @@ export const difficultyAtom = atom(
     set(progressAtom, { ...progress, difficulty: val })
   }
 )
+
+export const readWorldIntroAtom = atom(null, (get, set) => {
+  const worldProgress = get(worldProgressAtom)
+  if (worldProgress == null) return
+  set(worldProgressAtom, { ...worldProgress, readIntro: true })
+})
 
 export const completedAtom = atom(
   get => {

--- a/client/src/store/world-tree-atoms.ts
+++ b/client/src/store/world-tree-atoms.ts
@@ -42,11 +42,15 @@ export const worldCompletedAtom = atomFamily((worldId: string) => atom<boolean>(
 }))
 
 /** The first uncompleted level or `0` */
-export const firstIncompleteLevel = atomFamily((worldId: string) => atom<number>(get => {
+export const firstIncompleteLevelAtomFamily = atomFamily((worldId: string) => atom<number>(get => {
+  // note: `findIndex` returns `-1` on failure
   const firstIncompleteLevel = get(levelsCompletedAtomFamily(worldId)).findIndex(it => !it)
-  // note: `findIndex` returns `-1` on failure, therefore the indices
-  // `-1, 0, 1` indicate all that the introduction should be shown
-  return firstIncompleteLevel >= 1 ? firstIncompleteLevel : 0
+
+  if (firstIncompleteLevel > 1) return firstIncompleteLevel
+
+  const readIntro = get(worldProgressAtomFamily(worldId))?.readIntro
+
+  return readIntro ? 1 : 0
 }))
 
 /** A world is unlocked if all dependency worlds have been completed */


### PR DESCRIPTION
Clicking on the World or on Level 1 should display the world intro the first time this is done, but not anymore afterwards.


- Follow up of #494