### PR TITLE
fix: translate hints in branchs (part 2)

### DIFF
--- a/cypress/TestGame/.i18n/en/Game.pot
+++ b/cypress/TestGame/.i18n/en/Game.pot
@@ -1,28 +1,20 @@
 msgid ""
 msgstr "Project-Id-Version: Game v4.29.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-21\n"
+"POT-Creation-Date: 2026-04-23\n"
 "Last-Translator: \n"
 "Language-Team: none\n"
 "Language: en\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit"
 
-#: Game.Levels.DemoWorld
-msgid "Test World"
-msgstr ""
-
-#: GameServer.RpcHandlers
-msgid "level completed with warnings… 🎭"
-msgstr ""
-
-#: Game.Levels.DemoWorld.L01_HelloWorld
-msgid "Test Level"
-msgstr ""
-
 #. §0: `ℕ`
 #: Game.Levels.DemoWorld.L01_HelloWorld
 msgid "Commutativity on §0"
+msgstr ""
+
+#: Game.Levels.DemoWorld
+msgid "Test World"
 msgstr ""
 
 #: GameServer.RpcHandlers
@@ -32,6 +24,48 @@ msgstr ""
 #. §0: $\\textbf{LaTeX}$
 #: Game.Levels.DemoWorld.L01_HelloWorld
 msgid "This is a test level. There can be §0"
+msgstr ""
+
+#: GameServer.RpcHandlers
+msgid "intermediate goal solved! 🎉"
+msgstr ""
+
+#: Game.Levels.DemoWorld.L02_HypothesisNames
+#: Game.Levels.DemoWorld.L03_NonProp
+msgid "Done!"
+msgstr ""
+
+#: Game.Levels.DemoWorld.L01_HelloWorld
+msgid "Addition"
+msgstr ""
+
+#: Game
+msgid "This is a test game."
+msgstr ""
+
+#: Game
+#: Game
+msgid "Test Game"
+msgstr ""
+
+#: Game.Levels.DemoWorld.L01_HelloWorld
+msgid "An equality"
+msgstr ""
+
+#: Game.Levels.DemoWorld.L03_NonProp
+msgid "now apply!"
+msgstr ""
+
+#: Game.Levels.DemoWorld.L03_NonProp
+msgid "intro first!"
+msgstr ""
+
+#: Game.Levels.DemoWorld.L01_HelloWorld
+msgid "Test Level"
+msgstr ""
+
+#: GameServer.RpcHandlers
+msgid "level completed with warnings… 🎭"
 msgstr ""
 
 #: Game.Levels.DemoWorld.L01_HelloWorld
@@ -44,22 +78,18 @@ msgstr ""
 msgid "You should use §0 now."
 msgstr ""
 
-#: GameServer.RpcHandlers
-msgid "intermediate goal solved! 🎉"
-msgstr ""
-
-#: Game.Levels.DemoWorld.L02_HypothesisNames
-#: Game.Levels.DemoWorld.L03_NonProp
-msgid "Done!"
-msgstr ""
-
-#: Game.Levels.DemoWorld.L03_NonProp
-msgid "Non-Prop-Valued"
+#. §0: `«{h}»`
+#: Game.Levels.DemoWorld.L01_HelloWorld
+msgid "Maybe you should use §0 now."
 msgstr ""
 
 #: Game.Levels.DemoWorld.L02_HypothesisNames
 #: Game.Levels.DemoWorld.L03_NonProp
 msgid "This is a test level."
+msgstr ""
+
+#: Game.Levels.DemoWorld.L03_NonProp
+msgid "Non-Prop-Valued"
 msgstr ""
 
 #: Game
@@ -70,33 +100,12 @@ msgstr ""
 msgid "This last message appears if the level is solved."
 msgstr ""
 
-#: Game.Levels.DemoWorld.L01_HelloWorld
-msgid "Addition"
-msgstr ""
-
-#: Game
-msgid "This is a test game."
-msgstr ""
-
 #: Game
 msgid "This is the introduction text of the game."
 msgstr ""
 
-#: Game
-#: Game
-msgid "Test Game"
-msgstr ""
-
 #: Game.Levels.DemoWorld.L02_HypothesisNames
 msgid "Hypothesis Names"
-msgstr ""
-
-#: Game.Levels.DemoWorld.L03_NonProp
-msgid "now apply!"
-msgstr ""
-
-#: Game.Levels.DemoWorld.L01_HelloWorld
-msgid "An equality"
 msgstr ""
 
 #: Game.Levels.DemoWorld
@@ -107,8 +116,4 @@ msgstr ""
 #. §1: `«{g}»`
 #: Game.Levels.DemoWorld.L01_HelloWorld
 msgid "You can either start using §0 or §1."
-msgstr ""
-
-#: Game.Levels.DemoWorld.L03_NonProp
-msgid "intro first!"
 msgstr ""

--- a/cypress/TestGame/Game/Levels/DemoWorld/L01_HelloWorld.lean
+++ b/cypress/TestGame/Game/Levels/DemoWorld/L01_HelloWorld.lean
@@ -14,7 +14,7 @@ Statement (h : x = 2) (g: y = 4) : x + x = y := by
         using `{h}` or `{g}`."
   Branch
     rw [g]
-    Hint "You should use `{h}` now."
+    Hint "Maybe you should use `{h}` now."
     rw [h]
   rw [h]
   Hint "You should use `{g}` now."

--- a/cypress/e2e/game-features.cy.ts
+++ b/cypress/e2e/game-features.cy.ts
@@ -82,7 +82,7 @@ describe('Basic Lean4Game Features', () => {
       cy.contains('x + x = 4', { timeout: 10000 }).should('be.visible')
 
       // Check that the progressive hint appears
-      cy.contains('You should use h now').should('be.visible')
+      cy.contains('Maybe you should use h now').should('be.visible')
     })
 
     it('should show goal and hint in editor mode', () => {

--- a/server/GameServer/EnvExtensions.lean
+++ b/server/GameServer/EnvExtensions.lean
@@ -493,9 +493,7 @@ def getLevel? (levelId : LevelId) : m (Option GameLevel) := do
     | dbg_trace "no game id" return none
   let some world := game.worlds.nodes.get? levelId.world
     | dbg_trace "no world id" return none
-  let some level := world.levels.get? levelId.level
-    | dbg_trace "no level id" return none
-  return level
+  return world.levels.get? levelId.level
 
 def getCurGame [Monad m] : m Game := do
   let some game ← getGame? (← getCurGameId)

--- a/server/GameServer/Tactic/Branch.lean
+++ b/server/GameServer/Tactic/Branch.lean
@@ -27,7 +27,6 @@ elab (name := Branch) "Branch" t:tacticSeq : tactic => do
   let msgs ← Core.getMessageLog
   let envAfter ← getEnv
   let gameExtState := gameExt.getState envAfter
-
   let translationStateAfter := untranslatedKeysExt.getState envAfter
   let newHints := translationStateAfter.drop translationStateBefore.size
 

--- a/server/GameServer/Tactic/Branch.lean
+++ b/server/GameServer/Tactic/Branch.lean
@@ -9,6 +9,10 @@ open Lean Elab I18n
 proof state. We use it to define Hints for alternative proof methods or dead ends. -/
 elab (name := Branch) "Branch" t:tacticSeq : tactic => do
   let b ← saveState
+
+  let envBefore ← getEnv
+  let translationStateBefore := untranslatedKeysExt.getState envBefore
+
   Tactic.evalTactic t
 
   -- Show an info whether the branch proofs all remaining goals.
@@ -21,9 +25,11 @@ elab (name := Branch) "Branch" t:tacticSeq : tactic => do
 
   -- data to keep
   let msgs ← Core.getMessageLog
-  let env ← getEnv
-  let gameExtState := gameExt.getState env
-  let translationExtState := untranslatedKeysExt.getState env
+  let envAfter ← getEnv
+  let gameExtState := gameExt.getState envAfter
+
+  let translationStateAfter := untranslatedKeysExt.getState envAfter
+  let newHints := translationStateAfter.drop translationStateBefore.size
 
   -- restore state
   b.restore
@@ -31,4 +37,6 @@ elab (name := Branch) "Branch" t:tacticSeq : tactic => do
   -- add data which should be kept
   Core.setMessageLog msgs
   modifyEnv (fun env => gameExt.setState env gameExtState)
-  modifyEnv (fun env => untranslatedKeysExt.setState env translationExtState)
+
+  for hint in newHints do
+    modifyEnv (fun env => untranslatedKeysExt.addEntry env hint)

--- a/server/Test/HintInBranch.lean
+++ b/server/Test/HintInBranch.lean
@@ -1,0 +1,15 @@
+import GameServer.Commands
+
+Game "Test"
+World "Test"
+Level 1
+
+Statement : True := by
+  Branch
+    Hint "some hint inside branch"
+    skip
+  trivial
+
+/-- some hint inside branch -/
+#guard_msgs (substring := true) in
+ListTranslations


### PR DESCRIPTION
- mark hints in branches for translation
- add a test about this
- remove wrongly displayed info "no level id" when trying to set a level id

Closes: hhu-adam/lean-i18n#28