### PR TITLE
Update translation-guide-for-game-maintainers.md

### DIFF
--- a/doc/translation-guide-for-game-maintainers.md
+++ b/doc/translation-guide-for-game-maintainers.md
@@ -22,7 +22,7 @@ Share the files `Game.pot`, `glossary.csv` and any guidelines for translation wi
 
 ### 3. Review
 
-We strongly recommend getting translations reviewed by a member of the lean community familiar with the language before publication.  This is to prevent both illegible machine translations as well as offensive or inappropriate language from appearing on the server.  We recommend the tool [Poedit](https://poedit.net/) for working with `.pot` and `.po` files.  Among other advantages, it allows you to specifically review a given range of sentences, e.g. 50–100 at a time, so you can distribute the review workload.
+We strongly recommend getting translations reviewed by a member of the lean community familiar with the language before publication.  This is to prevent both illegible machine translations as well as offensive or inappropriate language from appearing on the server.  We recommend using a dedicated tool like [Poedit](https://poedit.net/) for working with `.pot` and `.po` files.  
 
 ### 4. Publication
 - Save the `.po` file with the translations to


### PR DESCRIPTION
Remove sentence about collaborative features of Poedit, which is misleading.  The feature referred to is simply that Poedit can number the strings for translation consecutively 1, 2, 3, … , so you can ask individual translators to review ranges:  "Please translate strings 50-100".  

 (The feature is hidden – you need to choose "View > Show string ID" from the menu).

However:

(a) This does not work properly - on my screen, the last digit of the id's is always cut off.  

(b) This is not a good workflow for achieving consistency.  It's much better to assign translators individual worlds of the game rather than random samples of 50 strings.