### PR TITLE
fix: relay path in ecosystem file

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   apps : [{
     name   : "lean4game",
-    script : "relay/dist/index.js",
+    script : "relay/dist/src/index.js",
     env: {
       LEAN4GAME_GITHUB_USER: "",
       LEAN4GAME_GITHUB_TOKEN: "",


### PR DESCRIPTION
The path of `index.js` changed in at some point.