### PR TITLE
feat: `LevelScope` set the scope of the level

### DIFF
--- a/relay/src/serverProcess.ts
+++ b/relay/src/serverProcess.ts
@@ -80,6 +80,44 @@ export class GameManager {
     }
   }
 
+  /**
+   * The directory of the game's copy of the `GameServer` lake package.
+   *
+   * Usually this is a git dependency in `.lake/packages/`, but when developing the game engine
+   * (`lake update -R -Klean4game.local`) it is a local path dependency, which lake records in
+   * the game's manifest.
+   */
+  getGameServerDir(gameDir: string) : string | null {
+    const manifestPath = path.join(gameDir, 'lake-manifest.json')
+    if (fs.existsSync(manifestPath)) {
+      try {
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+        const pkg = (manifest.packages ?? []).find((p: any) => p.name === 'GameServer')
+        if (pkg) {
+          const packagesDir = manifest.packagesDir ?? path.join('.lake', 'packages')
+          const dir = pkg.type === 'path'
+            ? path.resolve(gameDir, pkg.dir)
+            : path.join(gameDir, packagesDir, pkg.name, pkg.subDir ?? '')
+          if (fs.existsSync(dir)) return dir
+        }
+      } catch (e) {
+        console.error(`[${new Date()}] Could not read ${manifestPath}: ${e}`)
+      }
+    }
+    // Fallback for the usual layout in case the manifest is missing or unreadable
+    const dir = path.join(gameDir, '.lake', 'packages', 'GameServer', 'server')
+    return fs.existsSync(dir) ? dir : null
+  }
+
+  /** Whether the game's `GameServer` provides the `LevelScope` command (v4.31.0 and later). */
+  gameServerHasLevelScope(gameDir: string) : boolean {
+    const gameServerDir = this.getGameServerDir(gameDir)
+    if (!gameServerDir) return false
+    const runnerPath = path.join(gameServerDir, 'GameServer', 'Runner.lean')
+    return fs.existsSync(runnerPath) &&
+      fs.readFileSync(runnerPath, 'utf8').includes('elab "LevelScope"')
+  }
+
   createGameProcess(owner: string, repo: string, customLeanServer: string | null) {
     let game_dir = this.getGameDir(owner, repo);
     if (!game_dir) return;
@@ -187,6 +225,16 @@ export class GameManager {
     const gameDataPath = path.join(gameDir, '.lake', 'gamedata', `game.json`)
     const gameData = JSON.parse(fs.readFileSync(gameDataPath, 'utf8'))
 
+    // `LevelScope` is a command that applies the level's `open`s/`set_option`s before the
+    // `Runner` command is *parsed*, which is what makes scoped notation available to the
+    // player. Games pinned to an older `GameServer` do not know that command, so we only
+    // emit it if their copy of the library provides it.
+    const usesLevelScope = this.gameServerHasLevelScope(gameDir)
+    if (!usesLevelScope) {
+      console.warn(`[${new Date()}] Game uses a 'GameServer' without the 'LevelScope' command; ` +
+        `scoped notation will not be available in the editor: ${gameDir}`)
+    }
+
     /** Sending messages from the client to the server */
     socketConnection.forward(serverConnection, (message: any) => {
       if (message?.error) {
@@ -234,9 +282,14 @@ export class GameManager {
         }
 
         let content = message.params.textDocument.text;
+        // Note: `LevelScope` and `Runner` have to stay on the same line as each other so that
+        // the proof still starts on line `PROOF_START_LINE`.
+        const levelIdArgs =
+          `${JSON.stringify(gameData.name)} ${JSON.stringify(worldId)} ${levelId} `
         message.params.textDocument.text =
-          `import ${levelData.module} import GameServer.Runner \nRunner ` +
-          `${JSON.stringify(gameData.name)} ${JSON.stringify(worldId)} ${levelId} ` +
+          `import ${levelData.module} import GameServer.Runner \n` +
+          (usesLevelScope ? `LevelScope ${levelIdArgs}` : ``) +
+          `Runner ` + levelIdArgs +
           `(difficulty := ${difficulty}) ` +
           `(inventory := [${inventory.map(s => JSON.stringify(s)).join(',')}]) ` +
           `:= by\n${content}\n`

--- a/server/GameServer/Runner.lean
+++ b/server/GameServer/Runner.lean
@@ -93,6 +93,62 @@ where addMessageByDifficulty (s : MessageData) :=
     logAt stx s (if difficulty > 1 then .error else .warning)
   else pure ()
 
+/--
+The scope of the level (i.e. the `open`s, the current namespace, the `set_option`s and the
+`variable`s active at the `Statement` in the level file).
+
+All position information is stripped from the syntax it contains: these positions point into
+the level file and would otherwise be reported in the player's editor.
+-/
+def levelScope (level : GameLevel) : Elab.Command.Scope :=
+  { level.scope with
+    varDecls := level.scope.varDecls.map (⟨·.raw.rewriteBottomUp fun stx => stx.setInfo .none⟩)
+    attrs :=  level.scope.attrs.map (⟨·.raw.rewriteBottomUp fun stx => stx.setInfo .none⟩)
+  }
+
+/-- Activate the scoped declarations (`scoped notation`, `scoped instance`, `scoped attribute`,
+…) of all namespaces that are open in `scope`. -/
+def activateScopedInScope (scope : Elab.Command.Scope) : CommandElabM Unit := do
+  for od in scope.openDecls do
+    let .simple ns _ := od
+      | pure ()
+    activateScoped ns
+  -- entering `namespace A.B` activates the scoped declarations of both `A` and `A.B`
+  let mut ns := Name.anonymous
+  for component in scope.currNamespace.components do
+    ns := ns ++ component
+    activateScoped ns
+
+/--
+Set the scope of the level (`open`s, current namespace, `set_option`s, `variable`s) in the
+command state.
+
+This needs to be a command of its own, placed *before* `Runner`: Lean parses each command with
+the scope the command state has *before* that command is parsed. Everything that influences
+parsing – most notably `scoped notation` such as `𝓝` from `open Topology` – is therefore only
+available in the player's proof if the corresponding `open` has already been processed by an
+earlier command. The `withScope` inside `Runner` only affects elaboration and comes too late for
+the parser, which has already turned `𝓝 x` into an application of the unknown identifier `𝓝`.
+-/
+elab "LevelScope" gameId:str worldId:str levelId:num : command => do
+  let levelId := {game := gameId.getString, world := worldId.getString, level := levelId.getNat}
+
+  let some level ← getLevel? levelId
+    | logError m!"Level not found: {levelId}"
+
+  let scope := levelScope level
+  -- Only apply what the *parser* of the following command needs, i.e. the namespace and the
+  -- `open`s. Everything else (options, `variable`s, …) is applied by `Runner` itself.
+  --
+  -- In particular the level's options must not be copied here: they are recorded while the game
+  -- is built with `lake build` and hence contain `internal.cmdlineSnapshots := true`. Applied to
+  -- the scope of the file, that makes the language server drop the info tree of the `Runner`
+  -- command, and the game can then no longer display any goals or hints.
+  modifyScope fun fileScope => { fileScope with
+    currNamespace := scope.currNamespace
+    openDecls := scope.openDecls }
+  activateScopedInScope scope
+
 -- TODO(Alex): Use config parser?
 -- TODO(Alex): Ensure Runner is the last command in the file
 /-- Run a game level -/
@@ -108,17 +164,12 @@ elab "Runner" gameId:str worldId:str levelId:num
   let some level ← getLevel? levelId
     | logError m!"Level not found: {levelId}"
 
-  -- use open namespaces and options as in the level file
-  let scope := { level.scope with
-    varDecls := level.scope.varDecls.map (⟨·.raw.rewriteBottomUp fun stx => stx.setInfo .none⟩)
-    attrs :=  level.scope.attrs.map (⟨·.raw.rewriteBottomUp fun stx => stx.setInfo .none⟩)
-  }
+  -- use open namespaces and options as in the level file.
+  -- Note: this only affects elaboration; for anything that affects parsing (i.e. scoped
+  -- notation) the `LevelScope` command above has to be run as a separate, earlier command.
+  let scope := levelScope level
   Elab.Command.withScope (fun _ => scope) do
-    for od in scope.openDecls do
-      let .simple ns _ := od
-        | pure ()
-      activateScoped ns
-    activateScoped scope.currNamespace
+    activateScopedInScope scope
 
     -- Position before first tactic and any prepended whitespace
     let startPos := byStx.getTailInfo.getRange?.getD (Lean.Syntax.Range.mk 0 0) |>.stop


### PR DESCRIPTION
This PR fix the problem that we are not able to use some notations like `𝓝`, `𝓟` in the browser. Prepared by Claude. And I test it. 