### PR TITLE
fix: translate Infoview descriptions

### DIFF
--- a/client/src/components/infoview/main.tsx
+++ b/client/src/components/infoview/main.tsx
@@ -141,7 +141,6 @@ function DualEditorMain() {
 function ExerciseStatement({ showLeanStatement = false }) {
   const { t : gT } = useGameTranslation()
   const { t } = useTranslation()
-  const [gameId] = useAtom(gameIdAtom)
   const [{ data: levelInfo }] = useAtom(levelInfoAtom)
 
   if (!(levelInfo?.descrText || levelInfo?.descrFormat)) { return <></> }
@@ -149,7 +148,7 @@ function ExerciseStatement({ showLeanStatement = false }) {
     <div className="exercise-statement">
       {levelInfo?.descrText ?
         <Markdown>
-          {(levelInfo?.displayName ? `**${t("Theorem")}** \`${levelInfo?.displayName}\`: ` : '') + t(levelInfo?.descrText, {ns: gameId})}
+          {(levelInfo?.displayName ? `**${t("Theorem")}** \`${levelInfo?.displayName}\`: ` : '') + gT(levelInfo?.descrText)}
         </Markdown> : levelInfo?.displayName &&
         <Markdown>
           {(levelInfo?.displayName ? `**${t("Theorem")}** \`${levelInfo?.displayName}\`: ` : '') + gT(levelInfo?.descrText ?? "")}


### PR DESCRIPTION
Lean-i18n stores translation keys with inline code and LaTeX replaced by `§n` placeholders. For example, a description containing ``rw rfl`` is looked up using a key with `§0`, then the original code fragment is restored after translation. Looking up the raw text therefore misses those generated catalog entries.

Related to leanprover-community/NNG4#162.