### PR TITLE
feat: add per-game translation fallback

### DIFF
--- a/client/src/components/landing_page.tsx
+++ b/client/src/components/landing_page.tsx
@@ -27,25 +27,40 @@ function Tile({tileWithName}: {tileWithName: GameTileWithName}) {
   const { t, i18n } = useTranslation()
   const [, navigateToGame] = useAtom(gameIdAtom)
   const [preferences] = useAtom(preferencesAtom)
+  const [, rerenderAfterFallbackLoad] = React.useState(0)
 
   const gameTile = tileWithName.tile
   const gameId = `g/${tileWithName.owner}/${tileWithName.game}`
-  const gameI18n = getGameI18n(tileWithName.settings?.allowEmptyTranslations ?? false)
+  const fallbackLanguage = tileWithName.settings?.fallbackLanguage ?? "en"
+  React.useEffect(() => {
+    let active = true
+    void i18n.loadLanguages(fallbackLanguage).then(() => {
+      if (active) rerenderAfterFallbackLoad(n => n + 1)
+    })
+    return () => { active = false }
+  }, [fallbackLanguage, i18n])
+  const gameI18n = getGameI18n(tileWithName.settings)
   const gameT = gameI18n.getFixedT(i18n.resolvedLanguage ?? i18n.language)
+  const gameTranslationOptions = {
+    ns: gameId,
+    fallbackLng: fallbackLanguage,
+    returnEmptyString: tileWithName.settings?.allowEmptyTranslations || tileWithName.settings?.hideMissingTranslations,
+    ...(tileWithName.settings?.hideMissingTranslations ? { defaultValue: "" } : {}),
+  }
 
   return <div className="game" onClick={() => navigateToGame(gameId)}>
       <div className="wrapper">
-        <div className="title">{gameT(gameTile.title, {ns: gameId})}</div>
-        <div className="short-description">{gameT(gameTile.short, { ns: gameId })}
+        <div className="title">{gameT(gameTile.title, gameTranslationOptions)}</div>
+        <div className="short-description">{gameT(gameTile.short, gameTranslationOptions)}
         </div>
         { gameTile.image ? <img className="image" src={path.join("data", gameId, gameTile.image)} alt="" /> : <div className="image"/> }
-        <div className="long description"><Markdown>{gameT(gameTile.long, { ns: gameId })}</Markdown></div>
+        <div className="long description"><Markdown>{gameT(gameTile.long, gameTranslationOptions)}</Markdown></div>
       </div>
       <table className="info">
         <tbody>
         <tr>
           <td title="consider playing these games first.">{t("Prerequisites")}</td>
-          <td><Markdown>{gameT(gameTile.prerequisites.join(', '), { ns: gameId })}</Markdown></td>
+          <td><Markdown>{gameT(gameTile.prerequisites.join(', '), gameTranslationOptions)}</Markdown></td>
         </tr>
         <tr>
           <td>{t("Worlds")}</td>

--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -1,6 +1,7 @@
 import i18n from "i18next";
 import Backend from "i18next-http-backend"
 import { initReactI18next } from "react-i18next";
+import type { GameSettings } from "./store/api";
 
 i18n
 .use(initReactI18next)
@@ -36,20 +37,34 @@ i18n
     }
   });
 
-let emptyStringI18n: typeof i18n | undefined
+const gameI18nInstances = new Map<string, typeof i18n>()
 
 /**
  * Return an i18next instance for game strings.
  *
- * The clone shares loaded resources with the main instance, but treats an
- * explicit empty string as a valid translation. Keeping this option on a
- * separate instance prevents intentionally empty game strings from changing
- * fallback behaviour for the interface or for games which have not opted in.
+ * The clone shares loaded resources with the main instance, but keeps game
+ * fallback and missing-translation policy separate from the interface and
+ * other games.
  */
-export function getGameI18n(allowEmptyTranslations: boolean): typeof i18n {
-  if (!allowEmptyTranslations) return i18n
-  emptyStringI18n ??= i18n.cloneInstance({ returnEmptyString: true })
-  return emptyStringI18n
+export function getGameI18n(settings?: GameSettings): typeof i18n {
+  const fallbackLanguage = settings?.fallbackLanguage ?? "en"
+  const allowEmptyTranslations = settings?.allowEmptyTranslations ?? false
+  const hideMissingTranslations = settings?.hideMissingTranslations ?? false
+
+  if (fallbackLanguage === "en" && !allowEmptyTranslations && !hideMissingTranslations) {
+    return i18n
+  }
+
+  const key = JSON.stringify({ fallbackLanguage, allowEmptyTranslations, hideMissingTranslations })
+  let gameI18n = gameI18nInstances.get(key)
+  if (!gameI18n) {
+    gameI18n = i18n.cloneInstance({
+      fallbackLng: fallbackLanguage,
+      returnEmptyString: allowEmptyTranslations || hideMissingTranslations,
+    })
+    gameI18nInstances.set(key, gameI18n)
+  }
+  return gameI18n
 }
 
 export default i18n;

--- a/client/src/store/api.ts
+++ b/client/src/store/api.ts
@@ -25,6 +25,8 @@ export interface GameTileWithName {
 
 export interface GameSettings {
   allowEmptyTranslations?: boolean
+  fallbackLanguage?: string
+  hideMissingTranslations?: boolean
   unbundleHyps: boolean
 }
 

--- a/client/src/utils/translation.ts
+++ b/client/src/utils/translation.ts
@@ -1,5 +1,5 @@
 import { useAtom } from 'jotai';
-import { useContext } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation, UseTranslationResponse } from 'react-i18next'
 import { gameIdAtom } from '../store/location-atoms';
 import { gameInfoAtom } from '../store/query-atoms';
@@ -61,16 +61,31 @@ function normalizeKeyString(key: string): string{
 export function useGameTranslation(): UseTranslationResponse<'translation', undefined> {
   const [gameId] = useAtom(gameIdAtom)
   const [{ data: gameInfo }] = useAtom(gameInfoAtom)
+  const settings = gameInfo?.settings
 
   const { t, i18n, ...rest } = useTranslation()
-  const gameI18n = getGameI18n(gameInfo?.settings?.allowEmptyTranslations ?? false)
+  const fallbackLanguage = settings?.fallbackLanguage ?? "en"
+  const [, rerenderAfterFallbackLoad] = useState(0)
+  useEffect(() => {
+    let active = true
+    void i18n.loadLanguages(fallbackLanguage).then(() => {
+      if (active) rerenderAfterFallbackLoad(n => n + 1)
+    })
+    return () => { active = false }
+  }, [fallbackLanguage, i18n])
+  const gameI18n = getGameI18n(settings)
   const gameT = gameI18n.getFixedT(i18n.resolvedLanguage ?? i18n.language)
   const pattern = /(?<!\\)§(\d+)/g;
   const modifiedT = ((key: string | undefined) => {
     if (!key) return ""
     const { codeBlocks, key: keyWithoutBlocks } = extractCodeBlocks(key)
     // look-up the unmodified `key` in case of failure for backwards compatibility.
-    let translatedKey = gameT([keyWithoutBlocks, key], {ns: gameId})
+    let translatedKey = gameT([keyWithoutBlocks, key], {
+      ns: gameId,
+      fallbackLng: fallbackLanguage,
+      returnEmptyString: settings?.allowEmptyTranslations || settings?.hideMissingTranslations,
+      ...(settings?.hideMissingTranslations ? { defaultValue: "" } : {}),
+    })
     return translatedKey.replace(pattern, (_, num: string) => codeBlocks[Number(num)] ?? num);
   }) as typeof t
   return { t: modifiedT, i18n, ...rest }

--- a/cypress/TestGame/Game.lean
+++ b/cypress/TestGame/Game.lean
@@ -11,7 +11,7 @@ This is additional information about the game.
 "
 
 Languages "English"
-Settings (allowEmptyTranslations := true)
+Settings (allowEmptyTranslations := true) (fallbackLanguage := "de") (hideMissingTranslations := true)
 CaptionShort "Test Game"
 CaptionLong "This is a test game."
 -- Prerequisites "" -- add this if your game depends on other games

--- a/cypress/e2e/game-features.cy.ts
+++ b/cypress/e2e/game-features.cy.ts
@@ -278,18 +278,25 @@ describe('Basic Lean4Game Features', () => {
       cy.contains('Du kannst mit h oder g starten.').should('be.visible')
     })
 
-    it('should render an intentionally empty game translation', () => {
+    it('should keep an intentionally empty fallback translation empty', () => {
       cy.get('#menu-btn').click()
       cy.contains('Preferences').click()
       cy.get('.MuiSelect-select').click()
-      cy.get('li[data-value="de"]').click({ force: true })
+      cy.get('li[data-value="zh"]').click({ force: true })
       cy.get('.codicon').click()
 
       cy.contains('This is the introduction text of the game.').should('not.exist')
       cy.get('.chat-panel .hint').should('not.exist')
     })
 
-    it('should not change language of hints to selected language if translation is not available', () => {
+    it('should hide a game string missing from both translation languages', () => {
+      cy.get('#menu-btn').click()
+      cy.contains('Game Info').click()
+
+      cy.contains('This is additional information about the game.').should('not.exist')
+    })
+
+    it('should use the game fallback language when the selected translation is unavailable', () => {
       navigateToLevel()
       // Click menu button to open dropdown
       cy.get('#menu-btn').click()
@@ -305,8 +312,8 @@ describe('Basic Lean4Game Features', () => {
       // Close preferences
       cy.get('.codicon').click()
 
-      // Check that displayed language is english
-      cy.contains('You can either start using h or g.').should('be.visible')
+      // The TestGame config chooses German, rather than the global English fallback.
+      cy.contains('Du kannst mit h oder g starten.').should('be.visible')
     })
   })
 })

--- a/doc/translation-guide-for-game-maintainers.md
+++ b/doc/translation-guide-for-game-maintainers.md
@@ -12,6 +12,8 @@ The game server supports internationalisation ("i18n") using [lean-i18n](https:/
 
   For games written in a language different than English, you should set the correct source language (`sourceLang`) in `.i18n/config.json`. Afterwards, on `lake build` the template should appear under the chosen language, and can be translated (e.g. into English) as described above.  
 
+- A game can set its fallback translation with `Settings (fallbackLanguage := "en")`. When a player's selected language has no game translation, Lean4Game uses this language instead. For games whose source strings should never be shown to players, add `hideMissingTranslations := true`; strings missing from both languages are then empty. The default fallback is English and source strings remain visible, which is useful while developing a game.
+
 - *Optional:*  You can simplify the work of translators by providing an additional glossary of mathematical terminology, lean concepts and other key words that appear in your game and which you anticipate will be difficult to translate (words that a machine translator would probably get wrong). Just make a list of such words in a text file, one word per line, and save it as `.i18n/en/glossary.csv`.
 
 - *Optional:* We recommend maintaining a game-specific translation guide in addition to our generic [guide for translators](translation-guide-for-game-translators.md); see [Robo/Scribble](https://github.com/hhu-adam/Robo/blob/main/docs/TranslationGuide.md) for an example.

--- a/server/GameServer/Commands.lean
+++ b/server/GameServer/Commands.lean
@@ -131,13 +131,15 @@ elab "CoverImage" t:str : command => do
   modifyCurGame fun game => pure {game with
     tile := {game.tile with image := file}}
 
-syntax settingsArg := atomic(" (" (&"allowEmptyTranslations" <|> &"unbundleHyps") " := " withoutPosition(term) ")")
+syntax settingsArg := atomic(" (" (&"allowEmptyTranslations" <|> &"fallbackLanguage" <|> &"hideMissingTranslations" <|> &"unbundleHyps") " := " withoutPosition(term) ")")
 
 /--
 Settings to customise the game appearance. Usage `Settings (setting1 := val1) (setting2 := val2)`.
 Valid settings are:
 
 * (allowEmptyTranslations := false)
+* (fallbackLanguage := "en")
+* (hideMissingTranslations := false)
 * (unbundleHyps := false)
  -/
 elab "Settings " args:settingsArg* : command => do
@@ -148,6 +150,12 @@ elab "Settings " args:settingsArg* : command => do
       settings := { settings with allowEmptyTranslations := true }
     | `(settingsArg| (allowEmptyTranslations := false)) =>
       settings := { settings with allowEmptyTranslations := false }
+    | `(settingsArg| (fallbackLanguage := $language:str)) =>
+      settings := { settings with fallbackLanguage := language.getString }
+    | `(settingsArg| (hideMissingTranslations := true)) =>
+      settings := { settings with hideMissingTranslations := true }
+    | `(settingsArg| (hideMissingTranslations := false)) =>
+      settings := { settings with hideMissingTranslations := false }
     | `(settingsArg| (unbundleHyps := true)) => settings := { settings with unbundleHyps := true }
     | `(settingsArg| (unbundleHyps := false)) => settings := { settings with unbundleHyps := false }
     | _ => throwUnsupportedSyntax

--- a/server/GameServer/EnvExtensions.lean
+++ b/server/GameServer/EnvExtensions.lean
@@ -401,6 +401,16 @@ structure Game.Settings where
   -/
   allowEmptyTranslations : Bool := false
   /--
+  The language used for game strings when the player's selected language does
+  not contain a translation.
+  -/
+  fallbackLanguage : String := "en"
+  /--
+  If `true`, game strings without a translation in either the selected or
+  fallback language are rendered as empty instead of their source text.
+  -/
+  hideMissingTranslations : Bool := false
+  /--
   If `true`, display two hypotheses `A : Prop` and `B : Prop`
   instead of a joint `A B : Prop`.
   -/
@@ -415,8 +425,12 @@ instance : FromJson Game.Settings where
       | .ok value => fromJson? value
       | .error _ => .ok defaultValue
     let allowEmptyTranslations ← getBoolD "allowEmptyTranslations" false
+    let fallbackLanguage ← match json.getObjVal? "fallbackLanguage" with
+      | .ok value => fromJson? value
+      | .error _ => .ok "en"
+    let hideMissingTranslations ← getBoolD "hideMissingTranslations" false
     let unbundleHyps ← getBoolD "unbundleHyps" false
-    return { allowEmptyTranslations, unbundleHyps }
+    return { allowEmptyTranslations, fallbackLanguage, hideMissingTranslations, unbundleHyps }
 
 instance : Inhabited Game.Settings where
   default := {}

--- a/server/Test/GameSettings.lean
+++ b/server/Test/GameSettings.lean
@@ -8,6 +8,8 @@ private def oldSettingsJson := Json.mkObj [
 
 private def emptyTranslationsEnabledJson := Json.mkObj [
   ("allowEmptyTranslations", toJson true),
+  ("fallbackLanguage", toJson "de"),
+  ("hideMissingTranslations", toJson true),
   ("unbundleHyps", toJson false)
 ]
 
@@ -16,11 +18,13 @@ private def invalidSettingsJson := Json.mkObj [
 ]
 
 #guard match fromJson? (α := Game.Settings) oldSettingsJson with
-  | .ok settings => !settings.allowEmptyTranslations && !settings.unbundleHyps
+  | .ok settings => !settings.allowEmptyTranslations && settings.fallbackLanguage == "en" &&
+      !settings.hideMissingTranslations && !settings.unbundleHyps
   | .error _ => false
 
 #guard match fromJson? (α := Game.Settings) emptyTranslationsEnabledJson with
-  | .ok settings => settings.allowEmptyTranslations && !settings.unbundleHyps
+  | .ok settings => settings.allowEmptyTranslations && settings.fallbackLanguage == "de" &&
+      settings.hideMissingTranslations && !settings.unbundleHyps
   | .error _ => false
 
 #guard match fromJson? (α := Game.Settings) invalidSettingsJson with


### PR DESCRIPTION
Implements hhu-adam/lean-i18n#47. 

Adds game level translation settings:

- `fallbackLanguage := "en"`: language to use when the player’s selected language lacks a game translation.
- `hideMissingTranslations := false`: when enabled, strings missing from both the selected and fallback languages render as empty instead of exposing their source text.

The settings are backwards compatible in game JSON and available through `Settings` in game source.

Game translations now use the configured fallback per lookup.