### PR TITLE
Fix inventory gesture enter key focus

### DIFF
--- a/client/src/components/infoview/context.ts
+++ b/client/src/components/infoview/context.ts
@@ -79,11 +79,7 @@ const PREFIX_OVERRIDES: Record<string, string> = {
 }
 export function useAppendTypewriterInput() {
   const [typewriter, setTypewriter] = useAtom(typewriterContentAtom)
-  const [{ isSuggestionsMobileMode }] = useAtom(preferencesAtom)
-  return (shiftKey: boolean, suffix: string, isTheorem: boolean, isAssumption: boolean) => {
-    if (!isSuggestionsMobileMode && !shiftKey) {
-      return false
-    }
+  return (suffix: string, isTheorem: boolean, isAssumption: boolean) => {
     // Automagically detect and adjust punctuation for mobile keyboardless usage
     let _typewriter = typewriter.trim()
     if (!typewriter.length) {

--- a/client/src/components/infoview/goals.tsx
+++ b/client/src/components/infoview/goals.tsx
@@ -98,7 +98,7 @@ function Hyp({ hyp: h, mvarId }: HypProps) {
             key={i}
             // FIXME: 3rd argument looks wrong
             onClick={ev => {
-                appendTypewriterInput(ev.shiftKey, n, h.isAssumption ?? false, h.isAssumption ?? false)
+                appendTypewriterInput(n, h.isAssumption ?? false, h.isAssumption ?? false)
                 ev.stopPropagation()
             } }
         >

--- a/client/src/components/infoview/typewriter.tsx
+++ b/client/src/components/infoview/typewriter.tsx
@@ -23,6 +23,8 @@ export interface GameDiagnosticsParams {
   diagnostics: Diagnostic[];
 }
 
+const isSuggestionsMobileMode = 'ontouchstart' in document.documentElement;
+
 /** The input field */
 export function Typewriter({disabled}: {disabled?: boolean}) {
   let { t } = useTranslation()
@@ -79,8 +81,6 @@ export function Typewriter({disabled}: {disabled?: boolean}) {
     editor.setPosition(pos)
   }, [typewriter, editor])
 
-  const [{ isSuggestionsMobileMode }] = useAtom(preferencesAtom)
-
   useEffect(() => {
     if (oneLineEditor && oneLineEditor.getValue() !== typewriter) {
       oneLineEditor.setValue(typewriter)
@@ -94,7 +94,7 @@ export function Typewriter({disabled}: {disabled?: boolean}) {
       oneLineEditor.setPosition({ column: editor.getValue().length + 1, lineNumber: 1 })
       isSuggestionsMobileMode || oneLineEditor.focus()
     }
-  }, [oneLineEditor, hasEditor, isSuggestionsMobileMode, editor])
+  }, [oneLineEditor, hasEditor, editor])
 
   /** If the last step has an error, add the command to the typewriter. */
   useEffect(() => {

--- a/client/src/components/inventory/inventory_item.tsx
+++ b/client/src/components/inventory/inventory_item.tsx
@@ -35,7 +35,7 @@ export function InventoryItem({tile, isTheorem, recent=false, enableAll=false} :
 
   const insertItemName = (ev: any) => {
     // navigator.clipboard.writeText(tile.displayName)
-    appendTypewriterInput(ev.shiftKey, tile.displayName, isTheorem, false)
+    appendTypewriterInput(tile.displayName, isTheorem, false)
     setInserted(true)
     setInterval(() => {
       setInserted(false)

--- a/client/src/store/preferences-atoms.ts
+++ b/client/src/store/preferences-atoms.ts
@@ -5,7 +5,6 @@ export interface Preferences {
   layout: "mobile" | "auto" | "desktop"
   isSavePreferences: boolean
   language: string
-  isSuggestionsMobileMode: boolean // TODO: remove me
   useFlags: boolean
   showLockedInventory: boolean
 }
@@ -21,7 +20,6 @@ const defaultPreferences: Preferences = {
   layout: "auto",
   isSavePreferences: false,
   language: import.meta.env.VITE_CLIENT_DEFAULT_LANGUAGE || "en",
-  isSuggestionsMobileMode: true,
   useFlags: false,
   showLockedInventory: true,
 };


### PR DESCRIPTION
- Finish deleting `!isSuggestionsMobileMode && !shiftKey` from `context.ts` and `preferences-atoms.ts`
- Restore previous touchscreen detection in `typewriter.tsx`. `isSuggestionsMobileMode` focuses the textbox on desktop to let Enter submit the line, not cause another inventory gesture. On mobile, don't, to avoid bringing up the on-screen keyboard